### PR TITLE
Add viewBox to Mastercard logo

### DIFF
--- a/imgs/mastercard.svg
+++ b/imgs/mastercard.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="618" width="1000">
+<svg xmlns="http://www.w3.org/2000/svg" height="618" width="1000" viewBox="0 0 1000 618">
 <path fill="#EB001B" d="m308,0a309,309 0 1,0 2,0z"/>
 <path fill="#F79E1B" d="m690,0a309,309 0 1,0 2,0z"/>
 <path fill="#FF5F00" d="m500,66a309,309 0 0,0 0,486 309,309 0 0,0 0-486"/>


### PR DESCRIPTION
## Summary
- add a viewBox to the Mastercard SVG so it scales with the same proportions as other payment logos

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4048cafd0832cba55b78368866052