### PR TITLE
Add Naver Pay logo to payment store

### DIFF
--- a/frontend/src/stores/payment.ts
+++ b/frontend/src/stores/payment.ts
@@ -4,6 +4,7 @@ import { defineStore } from 'pinia'
 import alipayIcon from '@imgs/alipay.svg'
 import kakaopayIcon from '@imgs/kakaopay.svg'
 import mastercardIcon from '@imgs/mastercard.svg'
+import naverpayIcon from '@imgs/naverpay.svg'
 import paypalIcon from '@imgs/paypal.svg'
 import unionpayIcon from '@imgs/unionpay.svg'
 import visaIcon from '@imgs/visacard.svg'
@@ -45,6 +46,9 @@ export const usePaymentStore = defineStore('payment', () => {
       currency: 'KRW',
       provider: 'Naver Financial',
       status: 'coming-soon',
+      icons: [
+        { src: naverpayIcon, alt: 'Naver Pay logo' },
+      ],
     },
     {
       id: 'alipay-plus',


### PR DESCRIPTION
## Summary
- import the new Naver Pay asset into the payment store
- display the Naver Pay logo in the payment methods metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d406169780832c8d2dd3b673503475