### PR TITLE
Configure payment ordering per locale

### DIFF
--- a/frontend/src/config/paymentLayout.ts
+++ b/frontend/src/config/paymentLayout.ts
@@ -1,0 +1,50 @@
+import type { Locale } from '@/stores/i18n'
+import type { PaymentCurrency } from '@/stores/payment'
+
+export type PaymentLayoutConfig = {
+  sectionOrder: PaymentCurrency[]
+  methodOrder?: Partial<Record<PaymentCurrency, string[]>>
+}
+
+const DEFAULT_CONFIG: PaymentLayoutConfig = {
+  sectionOrder: ['GLOBAL', 'KRW'],
+  methodOrder: {
+    GLOBAL: ['credit-card', 'alipay', 'paypal'],
+  },
+}
+
+const LOCALE_CONFIGS: Partial<Record<Locale, PaymentLayoutConfig>> = {
+  ko: {
+    sectionOrder: ['KRW', 'GLOBAL'],
+  },
+  en: {
+    sectionOrder: ['GLOBAL', 'KRW'],
+    methodOrder: {
+      GLOBAL: ['credit-card', 'paypal', 'alipay'],
+    },
+  },
+  zh: {
+    sectionOrder: ['GLOBAL', 'KRW'],
+    methodOrder: {
+      GLOBAL: ['alipay'],
+    },
+  },
+}
+
+export const getPaymentLayoutConfig = (locale: Locale): PaymentLayoutConfig => {
+  const localeConfig = LOCALE_CONFIGS[locale]
+
+  if (!localeConfig) {
+    return DEFAULT_CONFIG
+  }
+
+  const mergedMethodOrder = {
+    ...(DEFAULT_CONFIG.methodOrder ?? {}),
+    ...(localeConfig.methodOrder ?? {}),
+  }
+
+  return {
+    sectionOrder: localeConfig.sectionOrder ?? DEFAULT_CONFIG.sectionOrder,
+    methodOrder: Object.keys(mergedMethodOrder).length ? mergedMethodOrder : undefined,
+  }
+}

--- a/frontend/src/stores/i18n.ts
+++ b/frontend/src/stores/i18n.ts
@@ -68,14 +68,14 @@ const messages: Record<Locale, Messages> = {
       'naverpay-qr': {
         description: 'We are preparing Naver Pay so you can pay with your points on the spot.',
       },
-      'alipay-plus': {
+      alipay: {
         description:
-          'We plan to connect major global e-wallets through Alipay+ so travellers can pay with the wallet they already use.',
+          'We plan to connect major global e-wallets through Alipay so travellers can pay with the wallet they already use.',
       },
       paypal: {
         description: 'Soon you will be able to complete your purchase with the PayPal account you already trust.',
       },
-      'visa-mastercard-unionpay': {
+      'credit-card': {
         description:
           'Visa, Mastercard, and UnionPay card payments are on the roadmap so you can tap into a familiar checkout everywhere.',
       },
@@ -134,13 +134,13 @@ const messages: Record<Locale, Messages> = {
       'naverpay-qr': {
         description: '현장에서도 네이버페이 포인트로 간편하게 결제할 수 있도록 준비 중이에요.',
       },
-      'alipay-plus': {
+      alipay: {
         description: '하나의 지갑으로 글로벌 주요 전자지갑을 연결해 결제를 지원할 계획이에요.',
       },
       paypal: {
         description: '글로벌 고객이 익숙한 PayPal 계정을 통해 손쉽게 결제할 수 있도록 준비하고 있어요.',
       },
-      'visa-mastercard-unionpay': {
+      'credit-card': {
         description: 'Visa, Mastercard, UnionPay 등 전 세계 카드 결제를 곧 제공할게요.',
       },
     },
@@ -198,13 +198,13 @@ const messages: Record<Locale, Messages> = {
       'naverpay-qr': {
         description: 'Naver Payでもその場でポイント決済できるよう準備中です。',
       },
-      'alipay-plus': {
-        description: 'Alipay+を通じて主要な海外電子ウォレットを連携し、いつものウォレットで支払えるようにします。',
+      alipay: {
+        description: 'Alipayを通じて主要な海外電子ウォレットを連携し、いつものウォレットで支払えるようにします。',
       },
       paypal: {
         description: '普段使いのPayPalアカウントで決済できるよう近日対応予定です。',
       },
-      'visa-mastercard-unionpay': {
+      'credit-card': {
         description: 'Visa・Mastercard・UnionPayなどの世界的なカード決済に近日対応します。',
       },
     },
@@ -262,13 +262,13 @@ const messages: Record<Locale, Messages> = {
       'naverpay-qr': {
         description: '我们正在筹备 Naver Pay，让你当场即可使用积分付款。',
       },
-      'alipay-plus': {
-        description: '我们计划通过 Alipay+ 接入主要的全球电子钱包，让旅客可以用熟悉的钱包付款。',
+      alipay: {
+        description: '我们计划通过 Alipay 接入主要的全球电子钱包，让旅客可以用熟悉的钱包付款。',
       },
       paypal: {
         description: '你很快就能用熟悉的 PayPal 账户轻松完成购买。',
       },
-      'visa-mastercard-unionpay': {
+      'credit-card': {
         description: '我们即将上线 Visa、Mastercard、UnionPay 等全球银行卡支付，让你随时享受熟悉的结账体验。',
       },
     },

--- a/frontend/src/stores/payment.ts
+++ b/frontend/src/stores/payment.ts
@@ -9,7 +9,7 @@ import paypalIcon from '@imgs/paypal.svg'
 import unionpayIcon from '@imgs/unionpay.svg'
 import visaIcon from '@imgs/visacard.svg'
 
-type PaymentMethod = {
+export type PaymentMethod = {
   id: string
   name: string
   description: string
@@ -23,6 +23,8 @@ type PaymentMethod = {
     alt: string
   }>
 }
+
+export type PaymentCurrency = PaymentMethod['currency']
 
 export const usePaymentStore = defineStore('payment', () => {
   const methods = ref<PaymentMethod[]>([
@@ -51,15 +53,15 @@ export const usePaymentStore = defineStore('payment', () => {
       ],
     },
     {
-      id: 'alipay-plus',
-      name: 'Alipay+',
+      id: 'alipay',
+      name: 'Alipay',
       description:
-        'We plan to connect major global e-wallets through Alipay+ so travellers can pay with the wallet they already use.',
+        'We plan to connect major global e-wallets through Alipay so travellers can pay with the wallet they already use.',
       currency: 'GLOBAL',
       provider: 'Ant Group',
       status: 'coming-soon',
       icons: [
-        { src: alipayIcon, alt: 'Alipay+ logo' },
+        { src: alipayIcon, alt: 'Alipay logo' },
       ],
     },
     {
@@ -74,8 +76,8 @@ export const usePaymentStore = defineStore('payment', () => {
       ],
     },
     {
-      id: 'visa-mastercard-unionpay',
-      name: 'Visa / Mastercard / UnionPay',
+      id: 'credit-card',
+      name: 'Credit Card',
       description: 'Worldwide card payments are on the roadmap so you can tap into a familiar checkout everywhere.',
       currency: 'GLOBAL',
       provider: 'Global Networks',
@@ -88,12 +90,21 @@ export const usePaymentStore = defineStore('payment', () => {
     },
   ])
 
-  const krwMethods = computed(() => methods.value.filter((method) => method.currency === 'KRW'))
-  const globalMethods = computed(() => methods.value.filter((method) => method.currency === 'GLOBAL'))
+  const methodsByCurrency = computed(() => {
+    const grouped: Record<PaymentCurrency, PaymentMethod[]> = {
+      KRW: [],
+      GLOBAL: [],
+    }
+
+    methods.value.forEach((method) => {
+      grouped[method.currency].push(method)
+    })
+
+    return grouped
+  })
 
   return {
     methods,
-    krwMethods,
-    globalMethods,
+    methodsByCurrency,
   }
 })


### PR DESCRIPTION
## Summary
- add a default `methodOrder` map so locale-specific overrides merge correctly with card, Alipay, then PayPal ordering by default
- prioritize PayPal ahead of Alipay for English locales
- simplify the global payment identifiers to `credit-card` and `alipay` across the config, store, and i18n copy

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68d40b34d2d4832c9d4c26e2face20b1