### PR TITLE
Adjust payment card icon layout

### DIFF
--- a/frontend/src/components/PaymentOptionCard.vue
+++ b/frontend/src/components/PaymentOptionCard.vue
@@ -44,29 +44,30 @@ const preparingCopy = computed(() => i18nStore.t('card.preparing'))
           {{ props.name }}
         </h3>
         <p class="text-sm text-slate-500">{{ props.provider }}</p>
-        <div
-          v-if="props.icons?.length"
-          class="mt-3 flex flex-wrap items-center gap-2"
-        >
-          <span
-            v-for="icon in props.icons"
-            :key="icon.src"
-            class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-100 shadow-inner"
-          >
-            <img
-              :src="icon.src"
-              :alt="icon.alt"
-              class="h-5 w-5"
-              loading="lazy"
-            >
-          </span>
-        </div>
       </div>
       <span
         class="inline-flex items-center rounded-full px-3 py-1 text-xs font-medium"
         :class="statusMeta[props.status].classes"
       >
         {{ statusMeta[props.status].label }}
+      </span>
+    </div>
+
+    <div
+      v-if="props.icons?.length"
+      class="mt-3 flex items-center gap-2 overflow-x-auto"
+    >
+      <span
+        v-for="icon in props.icons"
+        :key="icon.src"
+        class="inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-slate-100 shadow-inner"
+      >
+        <img
+          :src="icon.src"
+          :alt="icon.alt"
+          class="h-5 w-5"
+          loading="lazy"
+        >
       </span>
     </div>
 


### PR DESCRIPTION
## Summary
- separate payment method icons from the status badge row in the payment option card
- keep icon rows on a single line with horizontal scrolling when necessary

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8e8b9d114832cacf8d89c08945bb5