### PR TITLE
Remove lazy loading from rotating payment icons

### DIFF
--- a/frontend/src/components/PaymentOptionCard.vue
+++ b/frontend/src/components/PaymentOptionCard.vue
@@ -87,7 +87,6 @@ onBeforeUnmount(() => {
               :src="activeIcon.src"
               :alt="activeIcon.alt"
               class="h-6 w-6"
-              loading="lazy"
             >
           </Transition>
         </div>


### PR DESCRIPTION
## Summary
- remove lazy loading from the animated payment method icon so transitions stay smooth

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8f025ca50832c93b95d6641478669