### PR TITLE
Display supported payment currencies and add selector modal

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,12 +2,15 @@
 import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import PaymentOptionCard from './components/PaymentOptionCard.vue'
+import CurrencySelectorDialog from './components/CurrencySelectorDialog.vue'
 import { getPaymentLayoutConfig } from './config/paymentLayout'
 import { usePaymentStore } from './stores/payment'
 import { type Locale, useI18nStore } from './stores/i18n'
 
 const paymentStore = usePaymentStore()
-const { methodsByCurrency } = storeToRefs(paymentStore)
+const { methodsByCurrency, selectedMethodId, selectedMethod, isCurrencySelectorOpen } = storeToRefs(paymentStore)
+
+const { selectMethod, chooseCurrency, closeCurrencySelector } = paymentStore
 
 const i18nStore = useI18nStore()
 const { locale, availableLocales } = storeToRefs(i18nStore)
@@ -52,6 +55,18 @@ const formatLocaleLabel = (option: { label: string; nativeLabel: string }) =>
 const onLocaleChange = (event: Event) => {
   const target = event.target as HTMLSelectElement
   i18nStore.setLocale(target.value as Locale)
+}
+
+const onSelectMethod = (methodId: string) => {
+  selectMethod(methodId)
+}
+
+const onCurrencySelect = (currency: string) => {
+  chooseCurrency(currency)
+}
+
+const onCloseCurrencySelector = () => {
+  closeCurrencySelector()
 }
 </script>
 
@@ -132,11 +147,14 @@ const onLocaleChange = (event: Event) => {
             :key="method.id"
             :name="method.name"
             :description="method.description"
+            :supported-currencies="method.supportedCurrencies"
             :provider="method.provider"
             :status="method.status"
             :cta="method.cta"
             :url="method.url"
             :icons="method.icons"
+            :is-selected="method.id === selectedMethodId"
+            @select="onSelectMethod(method.id)"
           />
         </div>
       </section>
@@ -145,5 +163,14 @@ const onLocaleChange = (event: Event) => {
     <footer class="border-t border-slate-200 bg-white/90 py-6 text-center text-xs text-slate-500">
       {{ footerCopy }}
     </footer>
+
+    <CurrencySelectorDialog
+      v-if="selectedMethod"
+      :visible="isCurrencySelectorOpen"
+      :method-name="selectedMethod.name"
+      :currencies="selectedMethod.supportedCurrencies"
+      @select="onCurrencySelect"
+      @close="onCloseCurrencySelector"
+    />
   </div>
 </template>

--- a/frontend/src/components/CurrencySelectorDialog.vue
+++ b/frontend/src/components/CurrencySelectorDialog.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { useI18nStore } from '@/stores/i18n'
+
+interface Props {
+  visible: boolean
+  methodName: string
+  currencies: string[]
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  select: [string]
+  close: []
+}>()
+
+const i18nStore = useI18nStore()
+
+const title = computed(() => i18nStore.t('currencySelector.title'))
+const description = computed(() =>
+  i18nStore.t('currencySelector.description').replace('{method}', props.methodName),
+)
+const cancelLabel = computed(() => i18nStore.t('currencySelector.cancel'))
+
+const onBackdropClick = (event: MouseEvent) => {
+  if (event.target === event.currentTarget) {
+    emit('close')
+  }
+}
+
+const onSelectCurrency = (currency: string) => {
+  emit('select', currency)
+}
+
+const onClose = () => {
+  emit('close')
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="fade">
+      <div
+        v-if="props.visible"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-6"
+        @click="onBackdropClick"
+      >
+        <div class="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl" @click.stop>
+          <h3 class="text-lg font-semibold text-roadshop-primary">{{ title }}</h3>
+          <p class="mt-2 text-sm text-slate-600">{{ description }}</p>
+
+          <div class="mt-6 grid gap-3">
+            <button
+              v-for="currency in props.currencies"
+              :key="currency"
+              type="button"
+              class="flex items-center justify-between rounded-xl border border-roadshop-primary/20 px-4 py-3 text-roadshop-primary transition hover:border-roadshop-accent hover:bg-roadshop-highlight/60"
+              @click="onSelectCurrency(currency)"
+            >
+              <span class="text-sm font-semibold">{{ currency }}</span>
+              <span aria-hidden="true" class="text-roadshop-accent">→</span>
+            </button>
+          </div>
+
+          <button
+            type="button"
+            class="mt-6 w-full rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-500 transition hover:bg-slate-100"
+            @click="onClose"
+          >
+            {{ cancelLabel }}
+          </button>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/components/PaymentOptionCard.vue
+++ b/frontend/src/components/PaymentOptionCard.vue
@@ -6,6 +6,7 @@ import { useI18nStore } from '../stores/i18n'
 interface Props {
   name: string
   description: string
+  supportedCurrencies: string[]
   provider: string
   status: 'available' | 'coming-soon'
   cta?: string
@@ -14,9 +15,14 @@ interface Props {
     src: string
     alt: string
   }>
+  isSelected?: boolean
 }
 
 const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  select: []
+}>()
 
 const i18nStore = useI18nStore()
 
@@ -76,7 +82,13 @@ onBeforeUnmount(() => {
 
 <template>
   <article
-    class="group flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-sm backdrop-blur transition hover:-translate-y-1 hover:shadow-lg"
+    class="group flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white/80 p-6 text-left shadow-sm backdrop-blur transition hover:-translate-y-1 hover:shadow-lg focus:outline-none cursor-pointer"
+    :class="props.isSelected ? 'ring-2 ring-roadshop-accent' : ''"
+    role="button"
+    tabindex="0"
+    @click="emit('select')"
+    @keydown.enter.prevent="emit('select')"
+    @keydown.space.prevent="emit('select')"
   >
     <div class="flex items-start justify-between gap-4">
       <div class="flex flex-1 items-start gap-4">
@@ -102,6 +114,16 @@ onBeforeUnmount(() => {
         :class="statusMeta[props.status].classes"
       >
         {{ statusMeta[props.status].label }}
+      </span>
+    </div>
+
+    <div v-if="props.supportedCurrencies.length" class="flex flex-wrap gap-2 text-xs text-roadshop-primary">
+      <span
+        v-for="currency in props.supportedCurrencies"
+        :key="currency"
+        class="inline-flex items-center gap-1 rounded-full border border-roadshop-primary/20 bg-roadshop-highlight/60 px-3 py-1 font-semibold"
+      >
+        {{ currency }}
       </span>
     </div>
 

--- a/frontend/src/components/PaymentOptionCard.vue
+++ b/frontend/src/components/PaymentOptionCard.vue
@@ -16,6 +16,7 @@ interface Props {
     alt: string
   }>
   isSelected?: boolean
+  selectedCurrency?: string | null
 }
 
 const props = defineProps<Props>()
@@ -38,6 +39,12 @@ const statusMeta = computed(() => ({
 }))
 
 const preparingCopy = computed(() => i18nStore.t('card.preparing'))
+const selectedCurrencyCopy = computed(() =>
+  props.selectedCurrency
+    ? i18nStore.t('card.selectedCurrency').replace('{currency}', props.selectedCurrency)
+    : null,
+)
+const selectCurrencyPrompt = computed(() => i18nStore.t('card.selectCurrencyPrompt'))
 
 const activeIconIndex = ref(0)
 
@@ -127,12 +134,20 @@ onBeforeUnmount(() => {
       </span>
     </div>
 
+    <p
+      v-if="props.isSelected && selectedCurrencyCopy"
+      class="text-xs font-semibold text-roadshop-accent"
+    >
+      {{ selectedCurrencyCopy }}
+    </p>
+
     <p class="flex-1 text-sm leading-relaxed text-slate-600">
       {{ props.description }}
     </p>
 
-    <template v-if="props.status === 'available' && props.cta">
+    <template v-if="props.status === 'available'">
       <a
+        v-if="props.cta && props.url"
         :href="props.url"
         target="_blank"
         rel="noopener noreferrer"
@@ -141,6 +156,12 @@ onBeforeUnmount(() => {
         {{ props.cta }}
         <span aria-hidden="true">→</span>
       </a>
+      <p
+        v-else-if="props.isSelected && props.supportedCurrencies.length > 1"
+        class="text-xs text-roadshop-accent"
+      >
+        {{ selectCurrencyPrompt }}
+      </p>
     </template>
     <template v-else>
       <p class="text-xs text-slate-400">{{ preparingCopy }}</p>

--- a/frontend/src/stores/i18n.ts
+++ b/frontend/src/stores/i18n.ts
@@ -62,6 +62,11 @@ const messages: Record<Locale, Messages> = {
     language: {
       label: 'Language',
     },
+    currencySelector: {
+      title: 'Choose a currency',
+      description: 'Select the currency you want to use with {method}.',
+      cancel: 'Cancel',
+    },
     payment: {
       'kakao': {
         name: 'Kakao Transfer',
@@ -138,6 +143,11 @@ const messages: Record<Locale, Messages> = {
     language: {
       label: '언어',
     },
+    currencySelector: {
+      title: '통화를 선택하세요',
+      description: '{method}로 사용할 통화를 선택해 주세요.',
+      cancel: '닫기',
+    },
     payment: {
       'kakao': {
         name: '카카오송금',
@@ -211,6 +221,11 @@ const messages: Record<Locale, Messages> = {
     },
     language: {
       label: '言語',
+    },
+    currencySelector: {
+      title: '通貨を選択',
+      description: '{method}で利用する通貨を選んでください。',
+      cancel: '閉じる',
     },
     payment: {
       'kakao': {
@@ -286,6 +301,11 @@ const messages: Record<Locale, Messages> = {
     language: {
       label: '语言',
     },
+    currencySelector: {
+      title: '选择货币',
+      description: '请选择使用 {method} 时的付款货币。',
+      cancel: '关闭',
+    },
     payment: {
       'kakao': {
         name: 'Kakao 汇款',
@@ -328,7 +348,7 @@ const readStoredLocale = (): Locale | undefined => {
   try {
     const stored = window.localStorage.getItem(LOCALE_STORAGE_KEY)
     return stored && isSupportedLocale(stored) ? stored : undefined
-  } catch (error) {
+  } catch {
     return undefined
   }
 }
@@ -340,7 +360,7 @@ const persistLocale = (value: Locale) => {
 
   try {
     window.localStorage.setItem(LOCALE_STORAGE_KEY, value)
-  } catch (error) {
+  } catch {
     // Ignore storage errors (e.g., quota exceeded, privacy mode)
   }
 }

--- a/frontend/src/stores/i18n.ts
+++ b/frontend/src/stores/i18n.ts
@@ -55,6 +55,8 @@ const messages: Record<Locale, Messages> = {
     },
     card: {
       preparing: 'We are working hard to launch this option soon.',
+      selectedCurrency: 'Selected currency: {currency}',
+      selectCurrencyPrompt: 'Choose a currency to continue.',
     },
     footer: {
       message: '© {year} Stitchmon Roadshop. The official online payment center for your orders.',
@@ -136,6 +138,8 @@ const messages: Record<Locale, Messages> = {
     },
     card: {
       preparing: '곧 만나보실 수 있도록 열심히 준비하고 있어요.',
+      selectedCurrency: '선택한 통화: {currency}',
+      selectCurrencyPrompt: '진행하려면 통화를 선택해 주세요.',
     },
     footer: {
       message: '© {year} 스티치몬 로드샵. 공식 온라인 결제 센터입니다.',
@@ -215,6 +219,8 @@ const messages: Record<Locale, Messages> = {
     },
     card: {
       preparing: 'まもなくご利用いただけるよう準備を進めています。',
+      selectedCurrency: '選択した通貨: {currency}',
+      selectCurrencyPrompt: '続行するには通貨を選択してください。',
     },
     footer: {
       message: '© {year} スティッチモン ロードショップ。公式オンライン決済センターです。',
@@ -294,6 +300,8 @@ const messages: Record<Locale, Messages> = {
     },
     card: {
       preparing: '我们正在全力准备，敬请期待。',
+      selectedCurrency: '已选择的货币：{currency}',
+      selectCurrencyPrompt: '请选择货币以继续。',
     },
     footer: {
       message: '© {year} Stitchmon 路店。官方在线支付中心。',

--- a/frontend/src/stores/payment.ts
+++ b/frontend/src/stores/payment.ts
@@ -22,6 +22,7 @@ export type PaymentMethod = {
   status: 'available' | 'coming-soon'
   cta?: string
   url?: string
+  urlsByCurrency?: Record<string, string>
   icons?: Array<{
     src: string
     alt: string
@@ -81,6 +82,11 @@ export const usePaymentStore = defineStore('payment', () => {
       supportedCurrencies: ['CNY', 'HKD', 'USD'],
       provider: 'Ant Group',
       status: 'coming-soon',
+      urlsByCurrency: {
+        CNY: 'https://global.alipay.com/cny',
+        HKD: 'https://global.alipay.com/hkd',
+        USD: 'https://global.alipay.com/usd',
+      },
       icons: [
         { src: alipayIcon, alt: 'Alipay logo' },
       ],
@@ -93,6 +99,11 @@ export const usePaymentStore = defineStore('payment', () => {
       supportedCurrencies: ['USD', 'EUR', 'GBP'],
       provider: 'PayPal Holdings',
       status: 'coming-soon',
+      urlsByCurrency: {
+        USD: 'https://paypal.com/checkout?currency=USD',
+        EUR: 'https://paypal.com/checkout?currency=EUR',
+        GBP: 'https://paypal.com/checkout?currency=GBP',
+      },
       icons: [
         { src: paypalIcon, alt: 'PayPal logo' },
       ],
@@ -105,6 +116,12 @@ export const usePaymentStore = defineStore('payment', () => {
       supportedCurrencies: ['USD', 'EUR', 'JPY', 'KRW'],
       provider: 'Global Networks',
       status: 'coming-soon',
+      urlsByCurrency: {
+        USD: 'https://payments.example.com/card/usd',
+        EUR: 'https://payments.example.com/card/eur',
+        JPY: 'https://payments.example.com/card/jpy',
+        KRW: 'https://payments.example.com/card/krw',
+      },
       icons: [
         { src: visaIcon, alt: 'Visa logo' },
         { src: mastercardIcon, alt: 'Mastercard logo' },
@@ -170,6 +187,20 @@ export const usePaymentStore = defineStore('payment', () => {
     isCurrencySelectorOpen.value = false
   }
 
+  const getUrlForMethod = (methodId: string, currency?: string | null) => {
+    const method = methods.value.find((item) => item.id === methodId)
+
+    if (!method) {
+      return null
+    }
+
+    if (currency && method.urlsByCurrency?.[currency]) {
+      return method.urlsByCurrency[currency]
+    }
+
+    return method.url ?? null
+  }
+
   return {
     methods,
     methodsByCurrency,
@@ -180,5 +211,6 @@ export const usePaymentStore = defineStore('payment', () => {
     selectMethod,
     chooseCurrency,
     closeCurrencySelector,
+    getUrlForMethod,
   }
 })

--- a/frontend/src/stores/payment.ts
+++ b/frontend/src/stores/payment.ts
@@ -17,6 +17,7 @@ export type PaymentMethod = {
   name: string
   description: string
   currency: 'KRW' | 'GLOBAL'
+  supportedCurrencies: string[]
   provider: string
   status: 'available' | 'coming-soon'
   cta?: string
@@ -36,6 +37,7 @@ export const usePaymentStore = defineStore('payment', () => {
       name: 'Toss Transfer',
       description: 'Send your payment instantly with Toss for immediate confirmation.',
       currency: 'KRW',
+      supportedCurrencies: ['KRW'],
       provider: 'Viva Republica',
       status: 'available',
       cta: 'Open Toss',
@@ -49,6 +51,7 @@ export const usePaymentStore = defineStore('payment', () => {
       name: 'Kakao Transfer',
       description: 'Scan the QR code with KakaoTalk and finish checkout in seconds.',
       currency: 'KRW',
+      supportedCurrencies: ['KRW'],
       provider: 'KakaoBank Corp.',
       status: 'available',
       cta: 'Open Kakao Transfer',
@@ -62,6 +65,7 @@ export const usePaymentStore = defineStore('payment', () => {
       name: 'Naver Pay',
       description: 'We are preparing Naver Pay so you can pay with your points on the spot.',
       currency: 'KRW',
+      supportedCurrencies: ['KRW'],
       provider: 'Naver Financial',
       status: 'coming-soon',
       icons: [
@@ -74,6 +78,7 @@ export const usePaymentStore = defineStore('payment', () => {
       description:
         'We plan to connect major global e-wallets through Alipay so travellers can pay with the wallet they already use.',
       currency: 'GLOBAL',
+      supportedCurrencies: ['CNY', 'HKD', 'USD'],
       provider: 'Ant Group',
       status: 'coming-soon',
       icons: [
@@ -85,6 +90,7 @@ export const usePaymentStore = defineStore('payment', () => {
       name: 'PayPal',
       description: 'Soon you will be able to complete your purchase with the PayPal account you already trust.',
       currency: 'GLOBAL',
+      supportedCurrencies: ['USD', 'EUR', 'GBP'],
       provider: 'PayPal Holdings',
       status: 'coming-soon',
       icons: [
@@ -96,6 +102,7 @@ export const usePaymentStore = defineStore('payment', () => {
       name: 'Credit Card',
       description: 'Worldwide card payments are on the roadmap so you can tap into a familiar checkout everywhere.',
       currency: 'GLOBAL',
+      supportedCurrencies: ['USD', 'EUR', 'JPY', 'KRW'],
       provider: 'Global Networks',
       status: 'coming-soon',
       icons: [
@@ -121,8 +128,57 @@ export const usePaymentStore = defineStore('payment', () => {
     return grouped
   })
 
+  const selectedMethodId = ref<string | null>(null)
+  const selectedCurrency = ref<string | null>(null)
+  const isCurrencySelectorOpen = ref(false)
+
+  const selectedMethod = computed(() =>
+    selectedMethodId.value ? methods.value.find((method) => method.id === selectedMethodId.value) ?? null : null
+  )
+
+  const selectMethod = (methodId: string) => {
+    const method = methods.value.find((item) => item.id === methodId)
+
+    if (!method) {
+      return
+    }
+
+    selectedMethodId.value = methodId
+
+    if (method.supportedCurrencies.length <= 1) {
+      selectedCurrency.value = method.supportedCurrencies[0] ?? null
+      isCurrencySelectorOpen.value = false
+      return
+    }
+
+    selectedCurrency.value = null
+    isCurrencySelectorOpen.value = true
+  }
+
+  const chooseCurrency = (currency: string) => {
+    const method = selectedMethod.value
+
+    if (!method || !method.supportedCurrencies.includes(currency)) {
+      return
+    }
+
+    selectedCurrency.value = currency
+    isCurrencySelectorOpen.value = false
+  }
+
+  const closeCurrencySelector = () => {
+    isCurrencySelectorOpen.value = false
+  }
+
   return {
     methods,
     methodsByCurrency,
+    selectedMethodId,
+    selectedMethod,
+    selectedCurrency,
+    isCurrencySelectorOpen,
+    selectMethod,
+    chooseCurrency,
+    closeCurrencySelector,
   }
 })


### PR DESCRIPTION
## Summary
- surface supported currencies on payment option cards
- add selection state that opens a currency picker when a method supports multiple currencies
- localize the new currency selector dialog copy across available locales

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8f642e388832cb78ad874e03d3570