### PR TITLE
Trigger payment actions from payment cards

### DIFF
--- a/frontend/src/components/PaymentOptionCard.vue
+++ b/frontend/src/components/PaymentOptionCard.vue
@@ -9,14 +9,11 @@ interface Props {
   supportedCurrencies: string[]
   provider: string
   status: 'available' | 'coming-soon'
-  cta?: string
-  url?: string
   icons?: Array<{
     src: string
     alt: string
   }>
   isSelected?: boolean
-  selectedCurrency?: string | null
 }
 
 const props = defineProps<Props>()
@@ -39,11 +36,6 @@ const statusMeta = computed(() => ({
 }))
 
 const preparingCopy = computed(() => i18nStore.t('card.preparing'))
-const selectedCurrencyCopy = computed(() =>
-  props.selectedCurrency
-    ? i18nStore.t('card.selectedCurrency').replace('{currency}', props.selectedCurrency)
-    : null,
-)
 const selectCurrencyPrompt = computed(() => i18nStore.t('card.selectCurrencyPrompt'))
 
 const activeIconIndex = ref(0)
@@ -134,30 +126,13 @@ onBeforeUnmount(() => {
       </span>
     </div>
 
-    <p
-      v-if="props.isSelected && selectedCurrencyCopy"
-      class="text-xs font-semibold text-roadshop-accent"
-    >
-      {{ selectedCurrencyCopy }}
-    </p>
-
     <p class="flex-1 text-sm leading-relaxed text-slate-600">
       {{ props.description }}
     </p>
 
     <template v-if="props.status === 'available'">
-      <a
-        v-if="props.cta && props.url"
-        :href="props.url"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="inline-flex items-center justify-center gap-2 rounded-full bg-roadshop-accent px-4 py-2 text-sm font-semibold text-white shadow-inner transition hover:bg-emerald-500"
-      >
-        {{ props.cta }}
-        <span aria-hidden="true">→</span>
-      </a>
       <p
-        v-else-if="props.isSelected && props.supportedCurrencies.length > 1"
+        v-if="props.isSelected && props.supportedCurrencies.length > 1"
         class="text-xs text-roadshop-accent"
       >
         {{ selectCurrencyPrompt }}

--- a/frontend/src/stores/payment.ts
+++ b/frontend/src/stores/payment.ts
@@ -162,49 +162,7 @@ export const usePaymentStore = defineStore('payment', () => {
     return grouped
   })
 
-  const selectedMethodId = ref<string | null>(null)
-  const selectedCurrency = ref<string | null>(null)
-  const isCurrencySelectorOpen = ref(false)
-
-  const selectedMethod = computed(() =>
-    selectedMethodId.value ? methods.value.find((method) => method.id === selectedMethodId.value) ?? null : null
-  )
-
-  const selectMethod = (methodId: string) => {
-    const method = methods.value.find((item) => item.id === methodId)
-
-    if (!method) {
-      return
-    }
-
-    selectedMethodId.value = methodId
-
-    if (method.supportedCurrencies.length <= 1) {
-      selectedCurrency.value = method.supportedCurrencies[0] ?? null
-      isCurrencySelectorOpen.value = false
-      return
-    }
-
-    selectedCurrency.value = null
-    isCurrencySelectorOpen.value = true
-  }
-
-  const chooseCurrency = (currency: string) => {
-    const method = selectedMethod.value
-
-    if (!method || !method.supportedCurrencies.includes(currency)) {
-      return
-    }
-
-    selectedCurrency.value = currency
-    isCurrencySelectorOpen.value = false
-  }
-
-  const closeCurrencySelector = () => {
-    isCurrencySelectorOpen.value = false
-  }
-
-  const getUrlForMethod = (methodId: string, currency?: string | null) => {
+  const getUrlForMethod = (methodId: string, currency?: string | null): string | null => {
     const method = methods.value.find((item) => item.id === methodId)
 
     if (!method) {
@@ -216,6 +174,53 @@ export const usePaymentStore = defineStore('payment', () => {
     }
 
     return method.url ?? null
+  }
+
+  const selectedMethodId = ref<string | null>(null)
+  const selectedCurrency = ref<string | null>(null)
+  const isCurrencySelectorOpen = ref(false)
+
+  const selectedMethod = computed(() =>
+    selectedMethodId.value ? methods.value.find((method) => method.id === selectedMethodId.value) ?? null : null
+  )
+
+  const selectMethod = (methodId: string): string | null => {
+    const method = methods.value.find((item) => item.id === methodId)
+
+    if (!method) {
+      return null
+    }
+
+    selectedMethodId.value = methodId
+
+    if (method.supportedCurrencies.length <= 1) {
+      const currency = method.supportedCurrencies[0] ?? null
+      selectedCurrency.value = currency
+      isCurrencySelectorOpen.value = false
+      return getUrlForMethod(methodId, currency)
+    }
+
+    selectedCurrency.value = null
+    isCurrencySelectorOpen.value = true
+
+    return null
+  }
+
+  const chooseCurrency = (currency: string): string | null => {
+    const method = selectedMethod.value
+
+    if (!method || !method.supportedCurrencies.includes(currency)) {
+      return null
+    }
+
+    selectedCurrency.value = currency
+    isCurrencySelectorOpen.value = false
+
+    return getUrlForMethod(method.id, currency)
+  }
+
+  const closeCurrencySelector = () => {
+    isCurrencySelectorOpen.value = false
   }
 
   return {


### PR DESCRIPTION
## Summary
- remove the CTA button and selected-currency message from payment cards while keeping selection guidance
- trigger each payment method's action when the card is clicked and run the action after choosing a currency when multiple options exist
- return target URLs from the payment store so components can open them consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d91c047524832cac0d483e8976bcaf