### PR TITLE
Add payment action service with mobile fallback handling

### DIFF
--- a/frontend/src/components/ActionPopup.vue
+++ b/frontend/src/components/ActionPopup.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+interface Props {
+  visible: boolean
+  title: string
+  message: string
+  confirmLabel: string
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{ confirm: [] }>()
+
+const onConfirm = () => {
+  emit('confirm')
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="popup-fade">
+      <div
+        v-if="props.visible"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-6"
+        role="dialog"
+        aria-modal="true"
+      >
+        <div class="w-full max-w-sm rounded-2xl bg-white p-6 shadow-2xl">
+          <div class="flex flex-col gap-4">
+            <header class="space-y-2">
+              <h2 class="text-xl font-semibold text-roadshop-primary">{{ props.title }}</h2>
+              <p class="text-sm leading-relaxed text-slate-600">
+                {{ props.message }}
+              </p>
+            </header>
+            <footer class="flex justify-end">
+              <button
+                type="button"
+                class="rounded-full bg-roadshop-primary px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:bg-roadshop-primary/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-roadshop-accent"
+                @click="onConfirm"
+              >
+                {{ props.confirmLabel }}
+              </button>
+            </footer>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.popup-fade-enter-active,
+.popup-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.popup-fade-enter-from,
+.popup-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/config/info.json
+++ b/frontend/src/config/info.json
@@ -5,5 +5,11 @@
     },
     "bankName": "KB국민은행",
     "accountNo": "93800200352361"
+  },
+  "kakao": {
+    "amount": {
+      "krw": 10000
+    },
+    "personalCode": "000024398434938"
   }
 }

--- a/frontend/src/stores/i18n.ts
+++ b/frontend/src/stores/i18n.ts
@@ -64,6 +64,21 @@ const messages: Record<Locale, Messages> = {
     language: {
       label: 'Language',
     },
+    popups: {
+      deepLink: {
+        notMobile: {
+          title: 'Open on your mobile device',
+          message:
+            'This payment link works in the KakaoTalk or Toss app on mobile. Continue on your phone to keep going.',
+          confirm: 'Got it',
+        },
+        notInstalled: {
+          title: 'App not installed',
+          message: 'We could not open the payment app. Please check that KakaoTalk or Toss is installed and try again.',
+          confirm: 'OK',
+        },
+      },
+    },
     currencySelector: {
       title: 'Choose a currency',
       description: 'Select the currency you want to use with {method}.',
@@ -147,6 +162,21 @@ const messages: Record<Locale, Messages> = {
     language: {
       label: '언어',
     },
+    popups: {
+      deepLink: {
+        notMobile: {
+          title: '모바일에서만 이용할 수 있어요',
+          message:
+            '이 결제 링크는 모바일 카카오톡 또는 토스 앱에서만 열 수 있어요. 휴대폰에서 다시 시도해 주세요.',
+          confirm: '확인',
+        },
+        notInstalled: {
+          title: '앱이 설치되어 있지 않아요',
+          message: '결제 앱을 열 수 없었어요. 카카오톡 또는 토스 앱 설치 여부를 확인하고 다시 시도해 주세요.',
+          confirm: '확인',
+        },
+      },
+    },
     currencySelector: {
       title: '통화를 선택하세요',
       description: '{method}로 사용할 통화를 선택해 주세요.',
@@ -228,6 +258,21 @@ const messages: Record<Locale, Messages> = {
     language: {
       label: '言語',
     },
+    popups: {
+      deepLink: {
+        notMobile: {
+          title: 'モバイル専用です',
+          message:
+            'この決済リンクはモバイルのKakaoTalkまたはTossアプリでのみ開けます。スマートフォンでお試しください。',
+          confirm: '了解',
+        },
+        notInstalled: {
+          title: 'アプリが見つかりません',
+          message: '決済アプリを開けませんでした。KakaoTalkまたはTossアプリがインストールされているか確認して再試行してください。',
+          confirm: 'OK',
+        },
+      },
+    },
     currencySelector: {
       title: '通貨を選択',
       description: '{method}で利用する通貨を選んでください。',
@@ -308,6 +353,20 @@ const messages: Record<Locale, Messages> = {
     },
     language: {
       label: '语言',
+    },
+    popups: {
+      deepLink: {
+        notMobile: {
+          title: '仅限移动设备使用',
+          message: '此付款链接只能在手机上的 KakaoTalk 或 Toss 应用中打开。请在手机上继续操作。',
+          confirm: '知道了',
+        },
+        notInstalled: {
+          title: '未检测到应用',
+          message: '无法打开付款应用。请确认已安装 KakaoTalk 或 Toss 应用后再试一次。',
+          confirm: '好的',
+        },
+      },
     },
     currencySelector: {
       title: '选择货币',

--- a/frontend/src/stores/paymentActions.ts
+++ b/frontend/src/stores/paymentActions.ts
@@ -1,0 +1,224 @@
+import { computed, ref } from 'vue'
+import { defineStore, storeToRefs } from 'pinia'
+
+import info from '../config/info.json'
+import { useI18nStore } from './i18n'
+import { usePaymentStore, type PaymentMethod } from './payment'
+
+type PopupType = 'not-mobile' | 'not-installed'
+
+type PaymentInfo = {
+  toss?: {
+    amount?: {
+      krw?: number
+    }
+    bankName?: string
+    accountNo?: string
+  }
+  kakao?: {
+    amount?: {
+      krw?: number
+    }
+    personalCode?: string
+  }
+}
+
+type DeepLinkProvider = Exclude<PaymentMethod['deepLinkProvider'], undefined>
+
+const paymentInfo = info as PaymentInfo
+
+const isMobileDevice = () => {
+  if (typeof navigator === 'undefined') {
+    return false
+  }
+
+  const userAgent = navigator.userAgent || navigator.vendor || (window as typeof window & { opera?: string }).opera || ''
+
+  return /android|iphone|ipad|ipod|windows phone/i.test(userAgent)
+}
+
+const openUrlInNewTab = (url: string | null) => {
+  if (!url || typeof window === 'undefined') {
+    return
+  }
+
+  window.open(url, '_blank', 'noopener,noreferrer')
+}
+
+const toHexAmount = (value: number) => Math.round(value).toString(16).toUpperCase()
+
+const createTossDeepLink = () => {
+  const toss = paymentInfo.toss
+  if (!toss?.amount?.krw || !toss.bankName || !toss.accountNo) {
+    return null
+  }
+
+  const params = new URLSearchParams({
+    amount: toss.amount.krw.toString(),
+    bank: toss.bankName,
+    accountNo: toss.accountNo,
+  })
+
+  return `supertoss://send?${params.toString()}`
+}
+
+const createKakaoDeepLink = () => {
+  const kakao = paymentInfo.kakao
+  const amount = kakao?.amount?.krw
+  const personalCode = kakao?.personalCode
+
+  if (!amount || !personalCode) {
+    return null
+  }
+
+  const hexAmount = toHexAmount(amount * 8)
+
+  return `kakaotalk://kakaopay/money/to/qr?qr_code=281006011${personalCode}${hexAmount}0000`
+}
+
+const resolveDeepLink = (provider: DeepLinkProvider) => {
+  switch (provider) {
+    case 'toss':
+      return createTossDeepLink()
+    case 'kakao':
+      return createKakaoDeepLink()
+    default:
+      return null
+  }
+}
+
+export const usePaymentActionsStore = defineStore('payment-actions', () => {
+  const paymentStore = usePaymentStore()
+  const { isCurrencySelectorOpen, selectedCurrency, selectedMethod } = storeToRefs(paymentStore)
+  const i18nStore = useI18nStore()
+
+  const popupType = ref<PopupType | null>(null)
+
+  const isPopupVisible = computed(() => popupType.value !== null)
+
+  const popupContent = computed(() => {
+    if (!popupType.value) {
+      return null
+    }
+
+    if (popupType.value === 'not-mobile') {
+      return {
+        title: i18nStore.t('popups.deepLink.notMobile.title'),
+        message: i18nStore.t('popups.deepLink.notMobile.message'),
+        confirmLabel: i18nStore.t('popups.deepLink.notMobile.confirm'),
+      }
+    }
+
+    return {
+      title: i18nStore.t('popups.deepLink.notInstalled.title'),
+      message: i18nStore.t('popups.deepLink.notInstalled.message'),
+      confirmLabel: i18nStore.t('popups.deepLink.notInstalled.confirm'),
+    }
+  })
+
+  const closePopup = () => {
+    popupType.value = null
+  }
+
+  const showPopup = (type: PopupType) => {
+    popupType.value = type
+  }
+
+  const attemptDeepLinkLaunch = (url: string | null) => {
+    if (!url) {
+      showPopup('not-installed')
+      return
+    }
+
+    if (!isMobileDevice() || typeof window === 'undefined' || typeof document === 'undefined') {
+      showPopup('not-mobile')
+      return
+    }
+
+    let didLaunch = false
+
+    const cleanup = () => {
+      window.removeEventListener('blur', handleBlur)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      if (fallbackTimer) {
+        clearTimeout(fallbackTimer)
+      }
+    }
+
+    const handleBlur = () => {
+      didLaunch = true
+      cleanup()
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        didLaunch = true
+        cleanup()
+      }
+    }
+
+    const fallbackTimer = window.setTimeout(() => {
+      cleanup()
+      if (!didLaunch) {
+        showPopup('not-installed')
+      }
+    }, 1500)
+
+    window.addEventListener('blur', handleBlur)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    window.location.href = url
+  }
+
+  const handleMethodSelection = (methodId: string) => {
+    const method = paymentStore.getMethodById(methodId)
+
+    paymentStore.selectMethod(methodId)
+
+    if (!method || method.status !== 'available') {
+      return
+    }
+
+    if (isCurrencySelectorOpen.value) {
+      return
+    }
+
+    if (method.deepLinkProvider) {
+      attemptDeepLinkLaunch(resolveDeepLink(method.deepLinkProvider))
+      return
+    }
+
+    const url = paymentStore.getUrlForMethod(method.id, selectedCurrency.value ?? null)
+    openUrlInNewTab(url)
+  }
+
+  const handleCurrencySelection = (currency: string) => {
+    const method = selectedMethod.value
+
+    if (!method) {
+      return
+    }
+
+    paymentStore.chooseCurrency(currency)
+
+    if (method.status !== 'available') {
+      return
+    }
+
+    if (method.deepLinkProvider) {
+      attemptDeepLinkLaunch(resolveDeepLink(method.deepLinkProvider))
+      return
+    }
+
+    const url = paymentStore.getUrlForMethod(method.id, currency)
+    openUrlInNewTab(url)
+  }
+
+  return {
+    isPopupVisible,
+    popupContent,
+    closePopup,
+    handleMethodSelection,
+    handleCurrencySelection,
+  }
+})


### PR DESCRIPTION
## Summary
- create a dedicated payment actions Pinia store to manage deep links and mobile fallbacks
- update the payment store, app shell, and translations to support new deep link flows and popup messaging
- add a reusable popup component and Kakao deep link configuration with personal code metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d929e56a58832c88b24cb53944a20d