### PR TITLE
Refine deep link warnings and loading overlay

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4,6 +4,7 @@ import { storeToRefs } from 'pinia'
 import PaymentOptionCard from './components/PaymentOptionCard.vue'
 import CurrencySelectorDialog from './components/CurrencySelectorDialog.vue'
 import ActionPopup from './components/ActionPopup.vue'
+import LoadingOverlay from './components/LoadingOverlay.vue'
 import { getPaymentLayoutConfig } from './config/paymentLayout'
 import { usePaymentStore } from './stores/payment'
 import { usePaymentActionsStore } from './stores/paymentActions'
@@ -15,7 +16,7 @@ const paymentActionsStore = usePaymentActionsStore()
 const { methodsByCurrency, selectedMethodId, selectedMethod, selectedCurrency, isCurrencySelectorOpen } =
   storeToRefs(paymentStore)
 
-const { isPopupVisible, popupContent } = storeToRefs(paymentActionsStore)
+const { isPopupVisible, popupContent, isDeepLinkChecking } = storeToRefs(paymentActionsStore)
 
 const { closeCurrencySelector } = paymentStore
 
@@ -191,5 +192,6 @@ const onPopupConfirm = () => {
       :confirm-label="popupContent.confirmLabel"
       @confirm="onPopupConfirm"
     />
+    <LoadingOverlay :visible="isDeepLinkChecking" :message="i18nStore.t('loading.deepLink')" />
   </div>
 </template>

--- a/frontend/src/components/LoadingOverlay.vue
+++ b/frontend/src/components/LoadingOverlay.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+const props = defineProps<{
+  visible: boolean
+  message: string
+}>()
+</script>
+
+<template>
+  <div
+    v-if="props.visible"
+    class="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-slate-900/40 backdrop-blur"
+  >
+    <div class="flex items-center justify-center">
+      <div class="h-12 w-12 animate-spin rounded-full border-4 border-white/30 border-t-white"></div>
+    </div>
+    <p class="text-sm font-semibold text-white drop-shadow">
+      {{ props.message }}
+    </p>
+  </div>
+</template>

--- a/frontend/src/stores/i18n.ts
+++ b/frontend/src/stores/i18n.ts
@@ -64,6 +64,9 @@ const messages: Record<Locale, Messages> = {
     language: {
       label: 'Language',
     },
+    loading: {
+      deepLink: 'Opening the app to continue your payment…',
+    },
     popups: {
       deepLink: {
         titles: {
@@ -173,6 +176,9 @@ const messages: Record<Locale, Messages> = {
     language: {
       label: '언어',
     },
+    loading: {
+      deepLink: '결제 앱을 여는 중이에요…',
+    },
     popups: {
       deepLink: {
         titles: {
@@ -276,6 +282,9 @@ const messages: Record<Locale, Messages> = {
     },
     language: {
       label: '言語',
+    },
+    loading: {
+      deepLink: 'お支払いアプリを開いています…',
     },
     popups: {
       deepLink: {
@@ -383,6 +392,9 @@ const messages: Record<Locale, Messages> = {
     },
     language: {
       label: '语言',
+    },
+    loading: {
+      deepLink: '正在打开支付应用程序…',
     },
     popups: {
       deepLink: {

--- a/frontend/src/stores/paymentActions.ts
+++ b/frontend/src/stores/paymentActions.ts
@@ -98,6 +98,7 @@ export const usePaymentActionsStore = defineStore('payment-actions', () => {
   const i18nStore = useI18nStore()
 
   const popupState = ref<PopupState | null>(null)
+  const isDeepLinkChecking = ref(false)
 
   const isPopupVisible = computed(() => popupState.value !== null)
 
@@ -145,7 +146,13 @@ export const usePaymentActionsStore = defineStore('payment-actions', () => {
       return
     }
 
+    if (!isMobileDevice() && popupState.value?.type !== 'not-mobile') {
+      showPopup('not-mobile', provider)
+    }
+
     let didLaunch = false
+
+    isDeepLinkChecking.value = true
 
     const cleanup = () => {
       window.removeEventListener('blur', handleBlur)
@@ -153,6 +160,7 @@ export const usePaymentActionsStore = defineStore('payment-actions', () => {
       if (fallbackTimer) {
         clearTimeout(fallbackTimer)
       }
+      isDeepLinkChecking.value = false
     }
 
     const handleBlur = () => {
@@ -170,8 +178,11 @@ export const usePaymentActionsStore = defineStore('payment-actions', () => {
     const fallbackTimer = window.setTimeout(() => {
       cleanup()
       if (!didLaunch) {
-        const popupType = isMobileDevice() ? 'not-installed' : 'not-mobile'
-        showPopup(popupType, provider)
+        if (isMobileDevice()) {
+          showPopup('not-installed', provider)
+        } else if (popupState.value?.type !== 'not-mobile') {
+          showPopup('not-mobile', provider)
+        }
       }
     }, 1500)
 
@@ -228,6 +239,7 @@ export const usePaymentActionsStore = defineStore('payment-actions', () => {
   return {
     isPopupVisible,
     popupContent,
+    isDeepLinkChecking,
     closePopup,
     handleMethodSelection,
     handleCurrencySelection,


### PR DESCRIPTION
## Summary
- extract the deep link loading overlay into a reusable component and wire it into the app shell
- trigger the non-mobile warning as soon as a deep link launch starts while preserving the existing fallback flow

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68d93cca572c832c8d669f1909131bbe