### PR TITLE
Update KRW transfer description and reorder payment options

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,6 +5,7 @@ import PaymentOptionCard from './components/PaymentOptionCard.vue'
 import CurrencySelectorDialog from './components/CurrencySelectorDialog.vue'
 import ActionPopup from './components/ActionPopup.vue'
 import LoadingOverlay from './components/LoadingOverlay.vue'
+import TransferAccountsPopup from './components/TransferAccountsPopup.vue'
 import { getPaymentLayoutConfig } from './config/paymentLayout'
 import { usePaymentStore } from './stores/payment'
 import { usePaymentActionsStore } from './stores/paymentActions'
@@ -16,7 +17,8 @@ const paymentActionsStore = usePaymentActionsStore()
 const { methodsByCurrency, selectedMethodId, selectedMethod, selectedCurrency, isCurrencySelectorOpen } =
   storeToRefs(paymentStore)
 
-const { isPopupVisible, popupContent, isDeepLinkChecking } = storeToRefs(paymentActionsStore)
+const { isPopupVisible, popupContent, isDeepLinkChecking, isTransferPopupVisible, transferAccounts, transferAmount } =
+  storeToRefs(paymentActionsStore)
 
 const { closeCurrencySelector } = paymentStore
 
@@ -81,6 +83,10 @@ const onCloseCurrencySelector = () => {
 
 const onPopupConfirm = () => {
   paymentActionsStore.closePopup()
+}
+
+const onCloseTransferPopup = () => {
+  paymentActionsStore.closeTransferPopup()
 }
 </script>
 
@@ -191,6 +197,12 @@ const onPopupConfirm = () => {
       :message="popupContent.message"
       :confirm-label="popupContent.confirmLabel"
       @confirm="onPopupConfirm"
+    />
+    <TransferAccountsPopup
+      :visible="isTransferPopupVisible"
+      :accounts="transferAccounts"
+      :amount="transferAmount"
+      @close="onCloseTransferPopup"
     />
     <LoadingOverlay :visible="isDeepLinkChecking" :message="i18nStore.t('loading.deepLink')" />
   </div>

--- a/frontend/src/components/TransferAccountsPopup.vue
+++ b/frontend/src/components/TransferAccountsPopup.vue
@@ -1,0 +1,281 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, reactive, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+
+import { useI18nStore } from '@/stores/i18n'
+
+interface TransferAccount {
+  bank: string
+  number: string
+  holder: string
+}
+
+interface Props {
+  visible: boolean
+  amount: number
+  accounts: TransferAccount[]
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{ close: [] }>()
+
+const i18nStore = useI18nStore()
+const { locale } = storeToRefs(i18nStore)
+
+const firmIcons = import.meta.glob('@icons/firms/*.svg', {
+  eager: true,
+  import: 'default',
+}) as Record<string, string>
+
+const firmIconMap = Object.entries(firmIcons).reduce<Record<string, string>>((acc, [path, value]) => {
+  const segments = path.split('/')
+  const filename = segments[segments.length - 1] ?? ''
+  const name = filename.replace('.svg', '')
+  acc[name] = value
+  return acc
+}, {})
+
+const localeNumberFormats: Record<string, string> = {
+  en: 'en-US',
+  ko: 'ko-KR',
+  ja: 'ja-JP',
+  zh: 'zh-CN',
+}
+
+const numberFormatter = computed(() => new Intl.NumberFormat(localeNumberFormats[locale.value] ?? 'en-US'))
+const formattedAmount = computed(() => numberFormatter.value.format(props.amount))
+const formattedAmountWithCurrency = computed(() => {
+  switch (locale.value) {
+    case 'ko':
+      return `${formattedAmount.value}원`
+    case 'zh':
+      return `${formattedAmount.value} 韩元`
+    case 'ja':
+      return `${formattedAmount.value} KRW`
+    default:
+      return `${formattedAmount.value} KRW`
+  }
+})
+const formattedAmountForCopy = computed(() => new Intl.NumberFormat('ko-KR').format(props.amount))
+
+const title = computed(() => i18nStore.t('transferPopup.title'))
+const descriptionHtml = computed(() =>
+  i18nStore
+    .t('transferPopup.description')
+    .replace(
+      '{amountWithCurrency}',
+      `<strong class="font-semibold text-roadshop-primary">${formattedAmountWithCurrency.value}</strong>`,
+    ),
+)
+const copyAllLabel = computed(() => i18nStore.t('transferPopup.copyAll'))
+const copyNumberLabel = computed(() => i18nStore.t('transferPopup.copyNumber'))
+const copiedLabel = computed(() => i18nStore.t('transferPopup.copied'))
+const closeLabel = computed(() => i18nStore.t('transferPopup.close'))
+
+const getIconForBank = (bank: string) => firmIconMap[bank] ?? null
+
+type CopyStatus = 'all' | 'number' | null
+
+const copyStates = reactive<Record<string, CopyStatus>>({})
+const copyTimers = new Map<string, number>()
+
+const resetCopyStates = () => {
+  Object.keys(copyStates).forEach((key) => {
+    delete copyStates[key]
+  })
+  if (typeof window !== 'undefined') {
+    copyTimers.forEach((timeoutId) => {
+      window.clearTimeout(timeoutId)
+    })
+  }
+  copyTimers.clear()
+}
+
+const scheduleReset = (key: string) => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const previousTimer = copyTimers.get(key)
+  if (previousTimer) {
+    window.clearTimeout(previousTimer)
+  }
+
+  const timeoutId = window.setTimeout(() => {
+    copyStates[key] = null
+    copyTimers.delete(key)
+  }, 2000)
+
+  copyTimers.set(key, timeoutId)
+}
+
+const setCopyStatus = (key: string, status: Exclude<CopyStatus, null>) => {
+  copyStates[key] = status
+  scheduleReset(key)
+}
+
+const copyText = async (text: string) => {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // Ignore clipboard errors and fall back
+    }
+  }
+
+  if (typeof document === 'undefined') {
+    return false
+  }
+
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'absolute'
+  textarea.style.left = '-9999px'
+  document.body.appendChild(textarea)
+  textarea.select()
+
+  let success = false
+  try {
+    success = document.execCommand('copy')
+  } catch {
+    success = false
+  } finally {
+    document.body.removeChild(textarea)
+  }
+
+  return success
+}
+
+const handleCopyAll = async (account: TransferAccount) => {
+  const amountText = `${formattedAmountForCopy.value}원`
+  const payload = `${account.bank} ${account.number} ${account.holder}, ${amountText}`
+  const success = await copyText(payload)
+
+  if (success) {
+    setCopyStatus(account.number, 'all')
+  }
+}
+
+const handleCopyNumber = async (account: TransferAccount) => {
+  const success = await copyText(account.number)
+
+  if (success) {
+    setCopyStatus(account.number, 'number')
+  }
+}
+
+const onClose = () => {
+  emit('close')
+}
+
+watch(
+  () => props.visible,
+  (visible) => {
+    if (!visible) {
+      resetCopyStates()
+    }
+  },
+)
+
+onBeforeUnmount(() => {
+  resetCopyStates()
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="popup-fade">
+      <div v-if="props.visible" class="fixed inset-0 z-50">
+        <div class="absolute inset-0 bg-slate-900/60" @click="onClose"></div>
+        <div class="relative z-10 flex min-h-full items-center justify-center px-4 py-10">
+          <div class="w-full max-w-lg rounded-3xl bg-white p-6 shadow-2xl">
+            <header class="flex items-start justify-between gap-4">
+              <div>
+                <h2 class="text-xl font-semibold text-roadshop-primary">{{ title }}</h2>
+                <p
+                  class="mt-2 text-sm leading-relaxed text-slate-600"
+                  v-html="descriptionHtml"
+                ></p>
+              </div>
+              <button
+                type="button"
+                class="flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 text-slate-500 transition hover:bg-slate-100"
+                @click="onClose"
+              >
+                <span class="sr-only">{{ closeLabel }}</span>
+                <span aria-hidden="true" class="text-lg">×</span>
+              </button>
+            </header>
+            <ul class="mt-6 space-y-4">
+              <li
+                v-for="account in props.accounts"
+                :key="account.number"
+                class="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-roadshop-highlight/40 p-4 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div class="flex items-start gap-3">
+                  <div
+                    v-if="getIconForBank(account.bank)"
+                    class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-white shadow"
+                  >
+                    <img :src="getIconForBank(account.bank)" :alt="account.bank" class="h-7 w-7" />
+                  </div>
+                  <div>
+                    <p class="text-base font-semibold text-roadshop-primary">{{ account.bank }}</p>
+                    <p class="text-sm font-mono text-slate-700">{{ account.number }}</p>
+                    <p class="text-xs text-slate-500">{{ account.holder }}</p>
+                  </div>
+                </div>
+                <div class="flex flex-col items-start gap-1 text-sm font-semibold text-roadshop-primary sm:items-end">
+                  <button
+                    type="button"
+                    class="text-roadshop-primary underline decoration-roadshop-primary decoration-2 underline-offset-4 transition hover:text-roadshop-primary/90"
+                    @click="handleCopyAll(account)"
+                  >
+                    {{ copyAllLabel }}
+                  </button>
+                  <button
+                    type="button"
+                    class="text-roadshop-primary underline decoration-roadshop-primary decoration-2 underline-offset-4 transition hover:text-roadshop-primary/90"
+                    @click="handleCopyNumber(account)"
+                  >
+                    {{ copyNumberLabel }}
+                  </button>
+                  <p
+                    v-if="copyStates[account.number]"
+                    class="text-xs font-medium text-emerald-600"
+                  >
+                    {{ copiedLabel }}
+                  </p>
+                </div>
+              </li>
+            </ul>
+            <footer class="mt-6 flex justify-end">
+              <button
+                type="button"
+                class="rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100"
+                @click="onClose"
+              >
+                {{ closeLabel }}
+              </button>
+            </footer>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.popup-fade-enter-active,
+.popup-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.popup-fade-enter-from,
+.popup-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/config/info.json
+++ b/frontend/src/config/info.json
@@ -11,5 +11,22 @@
       "krw": 10000
     },
     "personalCode": "000024398434938"
+  },
+  "transfer": {
+    "amount": {
+      "krw": 10000
+    },
+    "account": [
+      {
+        "bank": "KB국민은행",
+        "number": "93800300352361",
+        "holder": "강일준"
+      },
+      {
+        "bank": "우리은행",
+        "number": "1002658182698",
+        "holder": "강일준"
+      }
+    ]
   }
 }

--- a/frontend/src/config/paymentLayout.ts
+++ b/frontend/src/config/paymentLayout.ts
@@ -10,7 +10,7 @@ const DEFAULT_CONFIG: PaymentLayoutConfig = {
   sectionOrder: ['GLOBAL', 'KRW'],
   methodOrder: {
     GLOBAL: ['card', 'alipay', 'paypal'],
-    KRW: ['toss', 'kakao', 'naver'],
+    KRW: ['kakao', 'toss', 'transfer', 'naver'],
   },
 }
 

--- a/frontend/src/stores/i18n.ts
+++ b/frontend/src/stores/i18n.ts
@@ -98,7 +98,19 @@ const messages: Record<Locale, Messages> = {
       description: 'Select the currency you want to use with {method}.',
       cancel: 'Cancel',
     },
+    transferPopup: {
+      title: 'Bank transfer details',
+      description: 'Send {amountWithCurrency} to one of the accounts below.',
+      copyAll: 'Copy whole details',
+      copyNumber: 'Copy only account number',
+      copied: 'Copied!',
+      close: 'Close',
+    },
     payment: {
+      transfer: {
+        name: 'Bank Transfer',
+        description: 'Pay the KRW amount by bank transfer.',
+      },
       'kakao': {
         name: 'Kakao Transfer',
         description: 'Scan the QR code with KakaoTalk and finish checkout in seconds.',
@@ -208,7 +220,19 @@ const messages: Record<Locale, Messages> = {
       description: '{method}로 사용할 통화를 선택해 주세요.',
       cancel: '닫기',
     },
+    transferPopup: {
+      title: '계좌이체 정보',
+      description: '{amountWithCurrency}을 아래 계좌 중 하나로 이체해 주세요.',
+      copyAll: '전체 정보 복사',
+      copyNumber: '계좌번호만 복사',
+      copied: '복사 완료!',
+      close: '닫기',
+    },
     payment: {
+      transfer: {
+        name: '계좌이체',
+        description: '원화 결제 금액을 계좌이체로 결제하세요.',
+      },
       'kakao': {
         name: '카카오송금',
         description: '카카오톡으로 QR을 스캔하고 빠르게 결제하세요.',
@@ -318,7 +342,19 @@ const messages: Record<Locale, Messages> = {
       description: '{method}で利用する通貨を選んでください。',
       cancel: '閉じる',
     },
+    transferPopup: {
+      title: '口座振込のご案内',
+      description: '下記のいずれかの口座へ {amountWithCurrency} をお振り込みください。',
+      copyAll: 'すべての情報をコピー',
+      copyNumber: '口座番号のみコピー',
+      copied: 'コピーしました！',
+      close: '閉じる',
+    },
     payment: {
+      transfer: {
+        name: '口座振込',
+        description: 'KRWの金額は口座振込でお支払いください。',
+      },
       'kakao': {
         name: 'Kakao送金',
         description: 'QRコードをKakaoTalkで読み取り、数秒で決済を完了できます。',
@@ -424,7 +460,19 @@ const messages: Record<Locale, Messages> = {
       description: '请选择使用 {method} 时的付款货币。',
       cancel: '关闭',
     },
+    transferPopup: {
+      title: '银行转账信息',
+      description: '请向下方任意账户转账 {amountWithCurrency}。',
+      copyAll: '复制全部信息',
+      copyNumber: '仅复制账号',
+      copied: '已复制！',
+      close: '关闭',
+    },
     payment: {
+      transfer: {
+        name: '银行转账',
+        description: '请通过银行转账支付韩元金额。',
+      },
       'kakao': {
         name: 'Kakao 汇款',
         description: '使用 KakaoTalk 扫描二维码，数秒内完成结账。',

--- a/frontend/src/stores/payment.ts
+++ b/frontend/src/stores/payment.ts
@@ -13,6 +13,7 @@ import amexIcon from '@icons/methods/amex.svg'
 import unionpayIcon from '@icons/methods/unionpay.svg'
 import visaIcon from '@icons/methods/visacard.svg'
 import jcbIcon from '@icons/methods/jcb.svg'
+import transferIcon from '@icons/methods/transfer.svg'
 
 type DeepLinkProvider = 'toss' | 'kakao'
 
@@ -41,6 +42,18 @@ const banks = (firmList as { banks?: FirmListEntry[] }).banks ?? []
 
 export const usePaymentStore = defineStore('payment', () => {
   const methods = ref<PaymentMethod[]>([
+    {
+      id: 'transfer',
+      name: 'Bank Transfer',
+      description: 'Transfer the payment amount directly to the Stitchmon account.',
+      currency: 'KRW',
+      supportedCurrencies: ['KRW'],
+      provider: 'Stitchmon Roadshop',
+      status: 'available',
+      icons: [
+        { src: transferIcon, alt: 'Bank transfer icon' },
+      ],
+    },
     {
       id: 'toss',
       name: 'Toss Transfer',

--- a/frontend/src/stores/paymentActions.ts
+++ b/frontend/src/stores/paymentActions.ts
@@ -26,6 +26,16 @@ type PaymentInfo = {
     }
     personalCode: string
   }
+  transfer: {
+    amount: {
+      krw: number
+    }
+    account: Array<{
+      bank: string
+      number: string
+      holder: string
+    }>
+  }
 }
 
 type DeepLinkProvider = Exclude<PaymentMethod['deepLinkProvider'], undefined>
@@ -91,6 +101,10 @@ export const usePaymentActionsStore = defineStore('payment-actions', () => {
 
   const popupState = ref<PopupState | null>(null)
   const isDeepLinkChecking = ref(false)
+  const isTransferPopupVisible = ref(false)
+
+  const transferAmount = computed(() => paymentInfo.transfer.amount.krw)
+  const transferAccounts = computed(() => paymentInfo.transfer.account)
 
   const isPopupVisible = computed(() => popupState.value !== null)
 
@@ -123,6 +137,14 @@ export const usePaymentActionsStore = defineStore('payment-actions', () => {
 
   const showPopup = (type: PopupType, provider: DeepLinkProvider) => {
     popupState.value = { type, provider }
+  }
+
+  const openTransferPopup = () => {
+    isTransferPopupVisible.value = true
+  }
+
+  const closeTransferPopup = () => {
+    isTransferPopupVisible.value = false
   }
 
   const attemptDeepLinkLaunch = (provider: DeepLinkProvider) => {
@@ -174,6 +196,11 @@ export const usePaymentActionsStore = defineStore('payment-actions', () => {
       return
     }
 
+    if (method.id === 'transfer') {
+      openTransferPopup()
+      return
+    }
+
     if (method.deepLinkProvider) {
       attemptDeepLinkLaunch(method.deepLinkProvider)
       return
@@ -196,6 +223,11 @@ export const usePaymentActionsStore = defineStore('payment-actions', () => {
       return
     }
 
+    if (method.id === 'transfer') {
+      openTransferPopup()
+      return
+    }
+
     if (method.deepLinkProvider) {
       attemptDeepLinkLaunch(method.deepLinkProvider)
       return
@@ -209,7 +241,11 @@ export const usePaymentActionsStore = defineStore('payment-actions', () => {
     isPopupVisible,
     popupContent,
     isDeepLinkChecking,
+    isTransferPopupVisible,
+    transferAmount,
+    transferAccounts,
     closePopup,
+    closeTransferPopup,
     handleMethodSelection,
     handleCurrencySelection,
   }


### PR DESCRIPTION
## Summary
- revise KRW bank transfer descriptions across locales to match the new guidance
- reorder the default KRW payment list to show Kakao, Toss, bank transfer, then Naver

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68d972a4df34832cba39d0b6583ca729