### PR TITLE
feat: improve transfer popup copy interactions

### DIFF
--- a/frontend/src/components/TooltipBubble.vue
+++ b/frontend/src/components/TooltipBubble.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface Props {
+  visible: boolean
+  message: string
+  variant?: 'default' | 'success'
+}
+
+const props = defineProps<Props>()
+
+const variantClasses = computed(() => {
+  if (props.variant === 'success') {
+    return {
+      bubble: 'bg-emerald-500 text-white',
+      arrow: 'border-t-emerald-500',
+    }
+  }
+
+  return {
+    bubble: 'bg-slate-800 text-white',
+    arrow: 'border-t-slate-800',
+  }
+})
+</script>
+
+<template>
+  <Transition name="tooltip-bubble-fade">
+    <div
+      v-if="props.visible"
+      class="pointer-events-none absolute left-1/2 top-0 z-20 -translate-x-1/2 -translate-y-3 transform whitespace-nowrap rounded-full px-3 py-1 text-xs font-semibold shadow-lg"
+      :class="variantClasses.bubble"
+      role="status"
+      aria-live="polite"
+    >
+      {{ props.message }}
+      <span
+        class="absolute left-1/2 top-full -translate-x-1/2 border-4 border-x-transparent border-b-transparent"
+        :class="variantClasses.arrow"
+        aria-hidden="true"
+      ></span>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.tooltip-bubble-fade-enter-active,
+.tooltip-bubble-fade-leave-active {
+  transition: opacity 0.15s ease;
+}
+
+.tooltip-bubble-fade-enter-from,
+.tooltip-bubble-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/components/TransferAccountsPopup.vue
+++ b/frontend/src/components/TransferAccountsPopup.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, reactive, watch } from 'vue'
+import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 
 import { useI18nStore } from '@/stores/i18n'
+import TooltipBubble from './TooltipBubble.vue'
 
 interface TransferAccount {
   bank: string
@@ -70,7 +71,9 @@ const descriptionHtml = computed(() =>
 )
 const copyAllLabel = computed(() => i18nStore.t('transferPopup.copyAll'))
 const copyNumberLabel = computed(() => i18nStore.t('transferPopup.copyNumber'))
+const copyTooltipLabel = computed(() => i18nStore.t('transferPopup.copyTooltip'))
 const copiedLabel = computed(() => i18nStore.t('transferPopup.copied'))
+const copiedNumberLabel = computed(() => i18nStore.t('transferPopup.copiedNumber'))
 const closeLabel = computed(() => i18nStore.t('transferPopup.close'))
 
 const getIconForBank = (bank: string) => firmIconMap[bank] ?? null
@@ -79,6 +82,40 @@ type CopyStatus = 'all' | 'number' | null
 
 const copyStates = reactive<Record<string, CopyStatus>>({})
 const copyTimers = new Map<string, number>()
+const hoveredControl = ref<string | null>(null)
+
+const controlKey = (accountNumber: string, action: Exclude<CopyStatus, null>) => `${accountNumber}:${action}`
+
+const setHoveredControl = (accountNumber: string, action: Exclude<CopyStatus, null>, value: boolean) => {
+  const key = controlKey(accountNumber, action)
+
+  if (value) {
+    hoveredControl.value = key
+    return
+  }
+
+  if (hoveredControl.value === key) {
+    hoveredControl.value = null
+  }
+}
+
+const isCopied = (accountNumber: string, action: Exclude<CopyStatus, null>) => copyStates[accountNumber] === action
+
+const isTooltipVisible = (accountNumber: string, action: Exclude<CopyStatus, null>) => {
+  const key = controlKey(accountNumber, action)
+  return hoveredControl.value === key || isCopied(accountNumber, action)
+}
+
+const getTooltipVariant = (accountNumber: string, action: Exclude<CopyStatus, null>) =>
+  isCopied(accountNumber, action) ? 'success' : 'default'
+
+const getTooltipMessage = (accountNumber: string, action: Exclude<CopyStatus, null>) => {
+  if (isCopied(accountNumber, action)) {
+    return action === 'all' ? copiedLabel.value : copiedNumberLabel.value
+  }
+
+  return action === 'all' ? copyTooltipLabel.value : copyNumberLabel.value
+}
 
 const resetCopyStates = () => {
   Object.keys(copyStates).forEach((key) => {
@@ -90,6 +127,7 @@ const resetCopyStates = () => {
     })
   }
   copyTimers.clear()
+  hoveredControl.value = null
 }
 
 const scheduleReset = (key: string) => {
@@ -224,31 +262,110 @@ onBeforeUnmount(() => {
                   </div>
                   <div>
                     <p class="text-base font-semibold text-roadshop-primary">{{ account.bank }}</p>
-                    <p class="text-sm font-mono text-slate-700">{{ account.number }}</p>
-                    <p class="text-xs text-slate-500">{{ account.holder }}</p>
+                    <div class="relative mt-1">
+                      <button
+                        type="button"
+                        class="flex items-center gap-2 rounded-lg border border-transparent px-2 py-1 font-mono text-sm text-slate-700 transition hover:border-roadshop-primary hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-roadshop-primary"
+                        @click="handleCopyNumber(account)"
+                        @mouseenter="setHoveredControl(account.number, 'number', true)"
+                        @mouseleave="setHoveredControl(account.number, 'number', false)"
+                        @focus="setHoveredControl(account.number, 'number', true)"
+                        @blur="setHoveredControl(account.number, 'number', false)"
+                      >
+                        <span>{{ account.number }}</span>
+                        <span class="flex h-5 w-5 items-center justify-center">
+                          <svg
+                            v-if="isCopied(account.number, 'number')"
+                            class="h-4 w-4 text-emerald-500"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            aria-hidden="true"
+                          >
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                          </svg>
+                          <svg
+                            v-else
+                            class="h-4 w-4 text-roadshop-primary"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            aria-hidden="true"
+                          >
+                            <path
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              d="M16 17h2a2 2 0 002-2V7a2 2 0 00-2-2h-6l-4 4v6a2 2 0 002 2h2"
+                            />
+                            <path
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              d="M8 17a2 2 0 01-2-2V9"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <TooltipBubble
+                        :visible="isTooltipVisible(account.number, 'number')"
+                        :message="getTooltipMessage(account.number, 'number')"
+                        :variant="getTooltipVariant(account.number, 'number')"
+                      />
+                    </div>
+                    <p class="mt-1 text-xs text-slate-500">{{ account.holder }}</p>
                   </div>
                 </div>
-                <div class="flex flex-col items-start gap-1 text-sm font-semibold text-roadshop-primary sm:items-end">
-                  <button
-                    type="button"
-                    class="text-roadshop-primary underline decoration-roadshop-primary decoration-2 underline-offset-4 transition hover:text-roadshop-primary/90"
-                    @click="handleCopyAll(account)"
-                  >
-                    {{ copyAllLabel }}
-                  </button>
-                  <button
-                    type="button"
-                    class="text-roadshop-primary underline decoration-roadshop-primary decoration-2 underline-offset-4 transition hover:text-roadshop-primary/90"
-                    @click="handleCopyNumber(account)"
-                  >
-                    {{ copyNumberLabel }}
-                  </button>
-                  <p
-                    v-if="copyStates[account.number]"
-                    class="text-xs font-medium text-emerald-600"
-                  >
-                    {{ copiedLabel }}
-                  </p>
+                <div class="flex items-start justify-start sm:items-end sm:justify-end">
+                  <div class="relative">
+                    <button
+                      type="button"
+                      class="flex h-11 w-11 items-center justify-center rounded-full border border-roadshop-primary text-roadshop-primary transition hover:bg-roadshop-primary hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-roadshop-primary"
+                      @click="handleCopyAll(account)"
+                      @mouseenter="setHoveredControl(account.number, 'all', true)"
+                      @mouseleave="setHoveredControl(account.number, 'all', false)"
+                      @focus="setHoveredControl(account.number, 'all', true)"
+                      @blur="setHoveredControl(account.number, 'all', false)"
+                    >
+                      <span class="sr-only">{{ copyAllLabel }}</span>
+                      <svg
+                        v-if="isCopied(account.number, 'all')"
+                        class="h-5 w-5 text-emerald-500"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        aria-hidden="true"
+                      >
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                      </svg>
+                      <svg
+                        v-else
+                        class="h-5 w-5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        aria-hidden="true"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          d="M8 16h8a2 2 0 002-2V6a2 2 0 00-2-2h-5l-5 5v5a2 2 0 002 2z"
+                        />
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          d="M15 20H7a2 2 0 01-2-2v-6"
+                        />
+                      </svg>
+                    </button>
+                    <TooltipBubble
+                      :visible="isTooltipVisible(account.number, 'all')"
+                      :message="getTooltipMessage(account.number, 'all')"
+                      :variant="getTooltipVariant(account.number, 'all')"
+                    />
+                  </div>
                 </div>
               </li>
             </ul>

--- a/frontend/src/stores/i18n.ts
+++ b/frontend/src/stores/i18n.ts
@@ -103,7 +103,9 @@ const messages: Record<Locale, Messages> = {
       description: 'Send {amountWithCurrency} to one of the accounts below.',
       copyAll: 'Copy whole details',
       copyNumber: 'Copy only account number',
+      copyTooltip: 'Copy to clipboard',
       copied: 'Copied!',
+      copiedNumber: 'Account number copied',
       close: 'Close',
     },
     payment: {
@@ -225,7 +227,9 @@ const messages: Record<Locale, Messages> = {
       description: '{amountWithCurrency}을 아래 계좌 중 하나로 이체해 주세요.',
       copyAll: '전체 정보 복사',
       copyNumber: '계좌번호만 복사',
-      copied: '복사 완료!',
+      copyTooltip: '클립보드로 복사',
+      copied: '복사됨!',
+      copiedNumber: '계좌번호만 복사됨',
       close: '닫기',
     },
     payment: {
@@ -347,7 +351,9 @@ const messages: Record<Locale, Messages> = {
       description: '下記のいずれかの口座へ {amountWithCurrency} をお振り込みください。',
       copyAll: 'すべての情報をコピー',
       copyNumber: '口座番号のみコピー',
+      copyTooltip: 'クリップボードにコピー',
       copied: 'コピーしました！',
+      copiedNumber: '口座番号のみコピーしました',
       close: '閉じる',
     },
     payment: {
@@ -465,7 +471,9 @@ const messages: Record<Locale, Messages> = {
       description: '请向下方任意账户转账 {amountWithCurrency}。',
       copyAll: '复制全部信息',
       copyNumber: '仅复制账号',
+      copyTooltip: '复制到剪贴板',
       copied: '已复制！',
+      copiedNumber: '仅复制了账号',
       close: '关闭',
     },
     payment: {


### PR DESCRIPTION
## Summary
- add a reusable TooltipBubble component to render speech bubble style messages for copy actions
- restyle the transfer account popup to use icon buttons with hover tooltips and success feedback when copying details or the account number
- translate the new tooltip and success copy into every supported locale

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d98834aaa0832c80cf4e456bae422f