### PR TITLE
refine transfer popup copy controls

### DIFF
--- a/frontend/src/components/TooltipBubble.vue
+++ b/frontend/src/components/TooltipBubble.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface Props {
+  visible: boolean
+  message: string
+  variant?: 'default' | 'success'
+}
+
+const props = defineProps<Props>()
+
+const variantClasses = computed(() => {
+  if (props.variant === 'success') {
+    return {
+      bubble: 'bg-emerald-500 text-white',
+      arrow: 'border-t-emerald-500',
+    }
+  }
+
+  return {
+    bubble: 'bg-slate-800 text-white',
+    arrow: 'border-t-slate-800',
+  }
+})
+</script>
+
+<template>
+  <Transition name="tooltip-bubble-fade">
+    <div
+      v-if="props.visible"
+      class="pointer-events-none absolute left-1/2 top-0 z-20 -translate-x-1/2 -translate-y-3 transform whitespace-nowrap rounded-full px-3 py-1 text-xs font-semibold shadow-lg"
+      :class="variantClasses.bubble"
+      role="status"
+      aria-live="polite"
+    >
+      {{ props.message }}
+      <span
+        class="absolute left-1/2 top-full -translate-x-1/2 border-4 border-x-transparent border-b-transparent"
+        :class="variantClasses.arrow"
+        aria-hidden="true"
+      ></span>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.tooltip-bubble-fade-enter-active,
+.tooltip-bubble-fade-leave-active {
+  transition: opacity 0.15s ease;
+}
+
+.tooltip-bubble-fade-enter-from,
+.tooltip-bubble-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/stores/i18n.ts
+++ b/frontend/src/stores/i18n.ts
@@ -103,7 +103,9 @@ const messages: Record<Locale, Messages> = {
       description: 'Send {amountWithCurrency} to one of the accounts below.',
       copyAll: 'Copy whole details',
       copyNumber: 'Copy only account number',
+      copyTooltip: 'Copy to clipboard',
       copied: 'Copied!',
+      copiedNumber: 'Account number copied',
       close: 'Close',
     },
     payment: {
@@ -225,7 +227,9 @@ const messages: Record<Locale, Messages> = {
       description: '{amountWithCurrency}을 아래 계좌 중 하나로 이체해 주세요.',
       copyAll: '전체 정보 복사',
       copyNumber: '계좌번호만 복사',
-      copied: '복사 완료!',
+      copyTooltip: '클립보드로 복사',
+      copied: '복사됨!',
+      copiedNumber: '계좌번호만 복사됨',
       close: '닫기',
     },
     payment: {
@@ -347,7 +351,9 @@ const messages: Record<Locale, Messages> = {
       description: '下記のいずれかの口座へ {amountWithCurrency} をお振り込みください。',
       copyAll: 'すべての情報をコピー',
       copyNumber: '口座番号のみコピー',
+      copyTooltip: 'クリップボードにコピー',
       copied: 'コピーしました！',
+      copiedNumber: '口座番号のみコピーしました',
       close: '閉じる',
     },
     payment: {
@@ -465,7 +471,9 @@ const messages: Record<Locale, Messages> = {
       description: '请向下方任意账户转账 {amountWithCurrency}。',
       copyAll: '复制全部信息',
       copyNumber: '仅复制账号',
+      copyTooltip: '复制到剪贴板',
       copied: '已复制！',
+      copiedNumber: '仅复制了账号',
       close: '关闭',
     },
     payment: {


### PR DESCRIPTION
## Summary
- add a reusable TooltipBubble component to render speech bubble style messages for copy actions
- restyle the transfer account popup to use icon buttons with hover tooltips and success feedback when copying details or the account number
- translate the new tooltip and success copy into every supported locale
- tweak the transfer popup styling to remove the header close icon, render the account number control like a link, and square off the copy button

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d98834aaa0832c80cf4e456bae422f