### PR TITLE
Align transfer popup layout and adjust tooltip offset

### DIFF
--- a/frontend/src/components/TooltipBubble.vue
+++ b/frontend/src/components/TooltipBubble.vue
@@ -28,7 +28,7 @@ const variantClasses = computed(() => {
   <Transition name="tooltip-bubble-fade">
     <div
       v-if="props.visible"
-      class="pointer-events-none absolute left-1/2 top-0 z-20 -translate-x-1/2 -translate-y-[15px] transform whitespace-nowrap rounded-full px-3 py-1 text-xs font-semibold shadow-lg"
+      class="pointer-events-none absolute left-1/2 top-0 z-20 -translate-x-1/2 -translate-y-1/5 transform whitespace-nowrap rounded-full px-3 py-1 text-xs font-semibold shadow-lg"
       :class="variantClasses.bubble"
       role="status"
       aria-live="polite"

--- a/frontend/src/components/TooltipBubble.vue
+++ b/frontend/src/components/TooltipBubble.vue
@@ -28,7 +28,7 @@ const variantClasses = computed(() => {
   <Transition name="tooltip-bubble-fade">
     <div
       v-if="props.visible"
-      class="pointer-events-none absolute left-1/2 top-0 z-20 -translate-x-1/2 -translate-y-3 transform whitespace-nowrap rounded-full px-3 py-1 text-xs font-semibold shadow-lg"
+      class="pointer-events-none absolute left-1/2 top-0 z-20 -translate-x-1/2 -translate-y-[15px] transform whitespace-nowrap rounded-full px-3 py-1 text-xs font-semibold shadow-lg"
       :class="variantClasses.bubble"
       role="status"
       aria-live="polite"

--- a/frontend/src/components/TransferAccountsPopup.vue
+++ b/frontend/src/components/TransferAccountsPopup.vue
@@ -253,7 +253,10 @@ onBeforeUnmount(() => {
                     <img :src="getIconForBank(account.bank)" :alt="account.bank" class="h-7 w-7" />
                   </div>
                   <div>
-                    <p class="text-base font-semibold text-roadshop-primary">{{ account.bank }}</p>
+                    <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                      <p class="text-base font-semibold text-roadshop-primary">{{ account.bank }}</p>
+                      <p class="text-xs text-slate-500">{{ account.holder }}</p>
+                    </div>
                     <div class="relative mt-1">
                       <button
                         type="button"
@@ -305,7 +308,6 @@ onBeforeUnmount(() => {
                         :variant="getTooltipVariant(account.number, 'number')"
                       />
                     </div>
-                    <p class="mt-1 text-xs text-slate-500">{{ account.holder }}</p>
                   </div>
                 </div>
                 <div class="flex items-start justify-start sm:items-end sm:justify-end">


### PR DESCRIPTION
## Summary
- display the account holder text alongside the bank name in the transfer popup header row
- raise the tooltip bubble by roughly 25% so it sits closer to the control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9fcdb7e80832cb287cd12c8fc8b7a