### PR TITLE
Apply i18n to transfer popup copy-all button

### DIFF
--- a/frontend/src/components/TransferAccountsPopup.vue
+++ b/frontend/src/components/TransferAccountsPopup.vue
@@ -305,18 +305,18 @@ onBeforeUnmount(() => {
                     >
                       <span class="flex items-center gap-2 sm:hidden">
                         <span class="text-sm font-semibold text-white">
-                          {{ isCopied(account.number, 'all') ? 'Copied to clipboard' : 'Copy account info' }}
+                          {{ isCopied(account.number, 'all') ? copiedLabel : copyAllLabel }}
                         </span>
                         <span
                           class="icon-wrapper flex h-4 w-4 items-center justify-center text-white"
                           aria-hidden="true"
-                          v-html="isCopied(account.number, 'all') ? successIcon : clipboardIcon"
+                          v-html="successIcon"
                         ></span>
                       </span>
                       <span
                         class="icon-wrapper hidden h-4 w-4 items-center justify-center text-white sm:flex"
                         aria-hidden="true"
-                        v-html="isCopied(account.number, 'all') ? successIcon : clipboardIcon"
+                        v-html="successIcon"
                       ></span>
                     </button>
                   </div>


### PR DESCRIPTION
## Summary
- apply internationalized labels to the transfer popup copy-all button text
- standardize the copy-all button to use the success icon instead of the clipboard icon

## Testing
- npm run lint *(fails: pre-existing unused variable errors in App.vue and stores/payment.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68da4bad7034832ca947dca2fa525ae0