### PR TITLE
Hide currency chips for KRW payment methods

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -172,6 +172,7 @@ const onCloseTransferPopup = () => {
             :status="method.status"
             :icons="method.icons"
             :is-selected="method.id === selectedMethodId"
+            :currency="method.currency"
             @select="onSelectMethod(method.id)"
           />
         </div>

--- a/frontend/src/components/PaymentOptionCard.vue
+++ b/frontend/src/components/PaymentOptionCard.vue
@@ -3,6 +3,8 @@ import { computed, onBeforeUnmount, ref, watch } from 'vue'
 
 import { useI18nStore } from '../stores/i18n'
 
+import { type PaymentCurrency } from '../stores/payment'
+
 interface Props {
   name: string
   description: string
@@ -14,6 +16,7 @@ interface Props {
     alt: string
   }>
   isSelected?: boolean
+  currency: PaymentCurrency
 }
 
 const props = defineProps<Props>()
@@ -109,7 +112,10 @@ onBeforeUnmount(() => {
       </span>
     </div>
 
-    <div v-if="props.supportedCurrencies.length" class="flex flex-wrap gap-2 text-xs text-roadshop-primary">
+    <div
+      v-if="props.currency !== 'KRW' && props.supportedCurrencies.length"
+      class="flex flex-wrap gap-2 text-xs text-roadshop-primary"
+    >
       <span
         v-for="currency in props.supportedCurrencies"
         :key="currency"


### PR DESCRIPTION
## Summary
- pass each payment card's currency type so KRW options can be detected
- hide supported currency chips for KRW methods while keeping them for global options

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da92a0081c832ca1d366811a05961e