### PR TITLE
Trigger payment deeplink twice to improve reliability

### DIFF
--- a/frontend/src/stores/paymentActions.ts
+++ b/frontend/src/stores/paymentActions.ts
@@ -181,6 +181,9 @@ export const usePaymentActionsStore = defineStore('payment-actions', () => {
     }, 1500)
 
     window.location.href = url
+    window.setTimeout(() => {
+      window.location.href = url
+    }, 200)
   }
 
   const handleMethodSelection = (methodId: string) => {


### PR DESCRIPTION
## Summary
- attempt to launch payment provider deep links twice in quick succession to improve reliability when opening payment apps

## Testing
- `npm run lint` *(fails: existing unused variable lint errors in App.vue and payment.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68da95d9eac4832cb9256e37c91d161c