### PR TITLE
Refactor payment dialogs to share reusable AppDialog wrapper

### DIFF
--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -71,8 +71,10 @@
   },
   "currencySelector": {
     "title": "Choose a currency",
-    "description": "Select the currency you want to use with {method}.",
-    "cancel": "Cancel"
+    "description": "Select the currency you want to use with {method}."
+  },
+  "dialog": {
+    "close": "Close"
   },
   "transferPopup": {
     "title": "Bank transfer details",
@@ -83,8 +85,7 @@
     "copyAllButton": "Copy transfer details",
     "copiedAllButton": "Copied to clipboard",
     "copied": "Copied!",
-    "copiedNumber": "Account number copied",
-    "close": "Close"
+    "copiedNumber": "Account number copied"
   },
   "payment": {
     "transfer": {

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -71,8 +71,10 @@
   },
   "currencySelector": {
     "title": "通貨を選択してください",
-    "description": "{method}で利用する通貨をお選びください。",
-    "cancel": "閉じる"
+    "description": "{method}で利用する通貨をお選びください。"
+  },
+  "dialog": {
+    "close": "閉じる"
   },
   "transferPopup": {
     "title": "口座振込のご案内",
@@ -83,8 +85,7 @@
     "copyAllButton": "振込情報をコピー",
     "copiedAllButton": "クリップボードにコピーしました",
     "copied": "コピーしました！",
-    "copiedNumber": "口座番号のみコピーしました",
-    "close": "閉じる"
+    "copiedNumber": "口座番号のみコピーしました"
   },
   "payment": {
     "transfer": {

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -71,8 +71,10 @@
   },
   "currencySelector": {
     "title": "통화를 선택하세요",
-    "description": "{method}로 사용할 통화를 선택해 주세요.",
-    "cancel": "닫기"
+    "description": "{method}로 사용할 통화를 선택해 주세요."
+  },
+  "dialog": {
+    "close": "닫기"
   },
   "transferPopup": {
     "title": "계좌이체 정보",
@@ -83,8 +85,7 @@
     "copyAllButton": "이체 정보 복사",
     "copiedAllButton": "클립보드에 복사됨",
     "copied": "복사됨!",
-    "copiedNumber": "계좌번호만 복사했어요",
-    "close": "닫기"
+    "copiedNumber": "계좌번호만 복사했어요"
   },
   "payment": {
     "transfer": {

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -71,8 +71,10 @@
   },
   "currencySelector": {
     "title": "选择货币",
-    "description": "请选择使用 {method} 时的付款货币。",
-    "cancel": "关闭"
+    "description": "请选择使用 {method} 时的付款货币。"
+  },
+  "dialog": {
+    "close": "关闭"
   },
   "transferPopup": {
     "title": "银行转账信息",
@@ -83,8 +85,7 @@
     "copyAllButton": "复制转账信息",
     "copiedAllButton": "已复制到剪贴板",
     "copied": "已复制！",
-    "copiedNumber": "仅复制了账号",
-    "close": "关闭"
+    "copiedNumber": "仅复制了账号"
   },
   "payment": {
     "transfer": {

--- a/frontend/src/payments/components/CurrencySelectorDialog.vue
+++ b/frontend/src/payments/components/CurrencySelectorDialog.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 
 import { useI18nStore } from '@/localization/store'
+import AppDialog from '@/shared/components/AppDialog.vue'
 
 interface Props {
   visible: boolean
@@ -22,13 +23,6 @@ const title = computed(() => i18nStore.t('currencySelector.title'))
 const description = computed(() =>
   i18nStore.t('currencySelector.description').replace('{method}', props.methodName),
 )
-const cancelLabel = computed(() => i18nStore.t('currencySelector.cancel'))
-
-const onBackdropClick = (event: MouseEvent) => {
-  if (event.target === event.currentTarget) {
-    emit('close')
-  }
-}
 
 const onSelectCurrency = (currency: string) => {
   emit('select', currency)
@@ -40,51 +34,24 @@ const onClose = () => {
 </script>
 
 <template>
-  <Teleport to="body">
-    <Transition name="fade">
-      <div
-        v-if="props.visible"
-        class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-6"
-        @click="onBackdropClick"
+  <AppDialog
+    :visible="props.visible"
+    :title="title"
+    :description="description"
+    close-alignment="full"
+    @close="onClose"
+  >
+    <div class="grid gap-3">
+      <button
+        v-for="currency in props.currencies"
+        :key="currency"
+        type="button"
+        class="flex items-center justify-between rounded-xl border border-roadshop-primary/20 px-4 py-3 text-roadshop-primary transition hover:border-roadshop-accent hover:bg-roadshop-highlight/60"
+        @click="onSelectCurrency(currency)"
       >
-        <div class="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl" @click.stop>
-          <h3 class="text-lg font-semibold text-roadshop-primary">{{ title }}</h3>
-          <p class="mt-2 text-sm text-slate-600">{{ description }}</p>
-
-          <div class="mt-6 grid gap-3">
-            <button
-              v-for="currency in props.currencies"
-              :key="currency"
-              type="button"
-              class="flex items-center justify-between rounded-xl border border-roadshop-primary/20 px-4 py-3 text-roadshop-primary transition hover:border-roadshop-accent hover:bg-roadshop-highlight/60"
-              @click="onSelectCurrency(currency)"
-            >
-              <span class="text-sm font-semibold">{{ currency }}</span>
-              <span aria-hidden="true" class="text-roadshop-accent">→</span>
-            </button>
-          </div>
-
-          <button
-            type="button"
-            class="mt-6 w-full rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-500 transition hover:bg-slate-100"
-            @click="onClose"
-          >
-            {{ cancelLabel }}
-          </button>
-        </div>
-      </div>
-    </Transition>
-  </Teleport>
+        <span class="text-sm font-semibold">{{ currency }}</span>
+        <span aria-hidden="true" class="text-roadshop-accent">→</span>
+      </button>
+    </div>
+  </AppDialog>
 </template>
-
-<style scoped>
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity 0.2s ease;
-}
-
-.fade-enter-from,
-.fade-leave-to {
-  opacity: 0;
-}
-</style>

--- a/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
+++ b/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
@@ -5,6 +5,7 @@ import { storeToRefs } from 'pinia'
 import { useI18nStore } from '@/localization/store'
 import type { TransferAccount } from '@/payments/services/paymentInfoService'
 import TooltipBubble from '@/shared/components/TooltipBubble.vue'
+import AppDialog from '@/shared/components/AppDialog.vue'
 import clipboardIcon from '@icons/ui/clipboard.svg?raw'
 import successIcon from '@icons/ui/success.svg?raw'
 
@@ -82,7 +83,6 @@ const copiedLabel = computed(() => i18nStore.t('transferPopup.copied'))
 const copiedNumberLabel = computed(() => i18nStore.t('transferPopup.copiedNumber'))
 const copyAllButtonLabel = computed(() => i18nStore.t('transferPopup.copyAllButton'))
 const copiedAllButtonLabel = computed(() => i18nStore.t('transferPopup.copiedAllButton'))
-const closeLabel = computed(() => i18nStore.t('transferPopup.close'))
 
 const getIconForBank = (bank: string) => firmIconMap[bank] ?? null
 
@@ -126,139 +126,109 @@ watch(
 </script>
 
 <template>
-  <Teleport to="body">
-    <Transition name="popup-fade">
-      <div v-if="props.visible" class="fixed inset-0 z-50">
-        <div class="absolute inset-0 bg-slate-900/60" @click="onClose"></div>
-        <div class="relative z-10 flex min-h-full items-center justify-center px-4 py-10">
-          <div class="w-full max-w-lg rounded-3xl bg-white p-6 shadow-2xl">
-            <header class="flex items-start justify-between gap-4">
-              <div>
-                <h2 class="text-xl font-semibold text-roadshop-primary">{{ title }}</h2>
-                <p
-                  class="mt-2 text-sm leading-relaxed text-slate-600"
-                  v-html="descriptionHtml"
-                ></p>
+  <AppDialog
+    :visible="props.visible"
+    :title="title"
+    :description="descriptionHtml"
+    size="lg"
+    close-alignment="end"
+    @close="onClose"
+  >
+    <ul class="space-y-4">
+      <li
+        v-for="account in props.accounts"
+        :key="account.number"
+        class="overflow-hidden rounded-2xl border border-slate-200 shadow-sm"
+      >
+        <div class="flex w-full flex-col items-stretch sm:flex-row sm:items-stretch">
+          <div class="flex flex-1 items-start gap-3 bg-roadshop-highlight/40 p-4">
+            <div
+              v-if="getIconForBank(account.bank)"
+              class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-white shadow"
+            >
+              <img :src="getIconForBank(account.bank)" :alt="account.bank" class="h-7 w-7" />
+            </div>
+            <div>
+              <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                <p class="text-base font-semibold text-roadshop-primary">{{ account.bank }}</p>
+                <p class="text-xs text-slate-500">{{ account.holder }}</p>
               </div>
-            </header>
-            <ul class="mt-6 space-y-4">
-              <li
-                v-for="account in props.accounts"
-                :key="account.number"
-                class="overflow-hidden rounded-2xl border border-slate-200 shadow-sm"
-              >
-                <div class="flex w-full flex-col items-stretch sm:flex-row sm:items-stretch">
-                  <div class="flex flex-1 items-start gap-3 bg-roadshop-highlight/40 p-4">
-                    <div
-                      v-if="getIconForBank(account.bank)"
-                      class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-white shadow"
-                    >
-                      <img :src="getIconForBank(account.bank)" :alt="account.bank" class="h-7 w-7" />
-                    </div>
-                    <div>
-                      <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-                        <p class="text-base font-semibold text-roadshop-primary">{{ account.bank }}</p>
-                        <p class="text-xs text-slate-500">{{ account.holder }}</p>
-                      </div>
-                      <div class="relative mt-1">
-                        <button
-                          type="button"
-                          class="group inline-flex items-center gap-1 font-mono text-sm text-roadshop-primary underline underline-offset-4"
-                          @click="copyAccountNumber(account)"
-                          @mouseenter="setHoverState(account.number, 'number', true)"
-                          @mouseleave="setHoverState(account.number, 'number', false)"
-                          @focus="setHoverState(account.number, 'number', true)"
-                          @blur="setHoverState(account.number, 'number', false)"
-                        >
-                          <span>{{ account.number }}</span>
-                          <span
-                            class="icon-wrapper flex h-3 w-3 items-center justify-center transition"
-                            :class="
-                              isCopied(account.number, 'number')
-                                ? 'text-emerald-500 group-hover:text-emerald-500'
-                                : 'text-roadshop-primary group-hover:text-roadshop-primary'
-                            "
-                            aria-hidden="true"
-                            v-html="isCopied(account.number, 'number') ? successIcon : clipboardIcon"
-                          ></span>
-                        </button>
-                        <TooltipBubble
-                          :visible="isTooltipVisible(account.number, 'number')"
-                          :message="getTooltipMessage(account.number, 'number')"
-                          :variant="getTooltipVariant(account.number, 'number')"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div class="relative flex sm:w-auto">
-                    <button
-                      type="button"
-                      :class="[
-                        'flex h-full min-h-[45px] w-full items-center justify-center gap-2 px-5 text-sm font-semibold text-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 sm:min-w-[64px]',
-                        isCopied(account.number, 'all')
-                          ? 'bg-emerald-500 hover:bg-emerald-500 focus-visible:outline-emerald-500'
-                          : 'bg-roadshop-primary hover:bg-roadshop-primary/90 focus-visible:outline-roadshop-primary',
-                      ]"
-                      :aria-label="copyAllLabel"
-                      @click="copyTransferDetails(account)"
-                      @mouseenter="setHoverState(account.number, 'all', true)"
-                      @mouseleave="setHoverState(account.number, 'all', false)"
-                      @focus="setHoverState(account.number, 'all', true)"
-                      @blur="setHoverState(account.number, 'all', false)"
-                    >
-                      <span class="flex items-center gap-2 sm:hidden">
-                        <span class="text-sm font-semibold text-white">
-                          {{ isCopied(account.number, 'all') ? copiedAllButtonLabel : copyAllButtonLabel }}
-                        </span>
-                        <span
-                          v-if="isCopied(account.number, 'all')"
-                          class="icon-wrapper h-4 w-4 text-white"
-                          aria-hidden="true"
-                          v-html="successIcon"
-                        ></span>
-                      </span>
-                      <span
-                        class="icon-wrapper hidden h-4 w-4 items-center justify-center text-white sm:flex"
-                        aria-hidden="true"
-                        v-html="isCopied(account.number, 'all') ? successIcon : clipboardIcon"
-                      ></span>
-                    </button>
-                    <TooltipBubble
-                      :visible="isTooltipVisible(account.number, 'all')"
-                      :message="getTooltipMessage(account.number, 'all')"
-                      :variant="getTooltipVariant(account.number, 'all')"
-                    />
-                  </div>
-                </div>
-              </li>
-            </ul>
-            <footer class="mt-6 flex justify-end">
-              <button
-                type="button"
-                class="rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100"
-                @click="onClose"
-              >
-                {{ closeLabel }}
-              </button>
-            </footer>
+              <div class="relative mt-1">
+                <button
+                  type="button"
+                  class="group inline-flex items-center gap-1 font-mono text-sm text-roadshop-primary underline underline-offset-4"
+                  @click="copyAccountNumber(account)"
+                  @mouseenter="setHoverState(account.number, 'number', true)"
+                  @mouseleave="setHoverState(account.number, 'number', false)"
+                  @focus="setHoverState(account.number, 'number', true)"
+                  @blur="setHoverState(account.number, 'number', false)"
+                >
+                  <span>{{ account.number }}</span>
+                  <span
+                    class="icon-wrapper flex h-3 w-3 items-center justify-center transition"
+                    :class="
+                      isCopied(account.number, 'number')
+                        ? 'text-emerald-500 group-hover:text-emerald-500'
+                        : 'text-roadshop-primary group-hover:text-roadshop-primary'
+                    "
+                    aria-hidden="true"
+                    v-html="isCopied(account.number, 'number') ? successIcon : clipboardIcon"
+                  ></span>
+                </button>
+                <TooltipBubble
+                  :visible="isTooltipVisible(account.number, 'number')"
+                  :message="getTooltipMessage(account.number, 'number')"
+                  :variant="getTooltipVariant(account.number, 'number')"
+                />
+              </div>
+            </div>
+          </div>
+          <div class="relative flex sm:w-auto">
+            <button
+              type="button"
+              :class="[
+                'flex h-full min-h-[45px] w-full items-center justify-center gap-2 px-5 text-sm font-semibold text-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 sm:min-w-[64px]',
+                isCopied(account.number, 'all')
+                  ? 'bg-emerald-500 hover:bg-emerald-500 focus-visible:outline-emerald-500'
+                  : 'bg-roadshop-primary hover:bg-roadshop-primary/90 focus-visible:outline-roadshop-primary',
+              ]"
+              :aria-label="copyAllLabel"
+              @click="copyTransferDetails(account)"
+              @mouseenter="setHoverState(account.number, 'all', true)"
+              @mouseleave="setHoverState(account.number, 'all', false)"
+              @focus="setHoverState(account.number, 'all', true)"
+              @blur="setHoverState(account.number, 'all', false)"
+            >
+              <span class="flex items-center gap-2 sm:hidden">
+                <span class="text-sm font-semibold text-white">
+                  {{ isCopied(account.number, 'all') ? copiedAllButtonLabel : copyAllButtonLabel }}
+                </span>
+                <span
+                  v-if="isCopied(account.number, 'all')"
+                  class="icon-wrapper h-4 w-4 text-white"
+                  aria-hidden="true"
+                  v-html="successIcon"
+                ></span>
+              </span>
+              <span
+                class="icon-wrapper hidden h-4 w-4 items-center justify-center text-white sm:flex"
+                aria-hidden="true"
+                v-html="isCopied(account.number, 'all') ? successIcon : clipboardIcon"
+              ></span>
+            </button>
+            <TooltipBubble
+              :visible="isTooltipVisible(account.number, 'all')"
+              :message="getTooltipMessage(account.number, 'all')"
+              :variant="getTooltipVariant(account.number, 'all')"
+            />
           </div>
         </div>
-      </div>
-    </Transition>
-  </Teleport>
+      </li>
+    </ul>
+  </AppDialog>
 </template>
 
 <style scoped>
-.popup-fade-enter-active,
-.popup-fade-leave-active {
-  transition: opacity 0.2s ease;
-}
-
-.popup-fade-enter-from,
-.popup-fade-leave-to {
-  opacity: 0;
-}
-
 .icon-wrapper :deep(svg) {
   width: 100%;
   height: 100%;

--- a/frontend/src/shared/components/AppDialog.vue
+++ b/frontend/src/shared/components/AppDialog.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { useI18nStore } from '@/localization/store'
+
+type DialogSize = 'md' | 'lg'
+type CloseAlignment = 'full' | 'end'
+
+const props = withDefaults(
+  defineProps<{
+    visible: boolean
+    title: string
+    description?: string
+    size?: DialogSize
+    closeAlignment?: CloseAlignment
+  }>(),
+  {
+    size: 'md' as DialogSize,
+    closeAlignment: 'full' as CloseAlignment,
+  },
+)
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const i18nStore = useI18nStore()
+
+const closeLabel = computed(() => i18nStore.t('dialog.close'))
+
+const containerWidthClass = computed(() => {
+  switch (props.size) {
+    case 'lg':
+      return 'max-w-lg'
+    default:
+      return 'max-w-md'
+  }
+})
+
+const footerClass = computed(() =>
+  props.closeAlignment === 'end' ? 'mt-6 flex justify-end' : 'mt-6',
+)
+
+const closeButtonClass = computed(() =>
+  props.closeAlignment === 'end'
+    ? 'rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100'
+    : 'w-full rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-500 transition hover:bg-slate-100',
+)
+
+const onBackdropClick = (event: MouseEvent) => {
+  if (event.target === event.currentTarget) {
+    emit('close')
+  }
+}
+
+const onClose = () => {
+  emit('close')
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="dialog-fade">
+      <div
+        v-if="props.visible"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-6"
+        @click="onBackdropClick"
+      >
+        <div class="w-full rounded-2xl bg-white p-6 shadow-xl" :class="containerWidthClass" @click.stop>
+          <header class="space-y-2">
+            <h3 class="text-lg font-semibold text-roadshop-primary">{{ props.title }}</h3>
+            <p v-if="props.description" class="text-sm text-slate-600" v-html="props.description"></p>
+          </header>
+          <div class="mt-6">
+            <slot />
+          </div>
+          <footer :class="footerClass">
+            <button type="button" :class="closeButtonClass" @click="onClose">
+              {{ closeLabel }}
+            </button>
+          </footer>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.dialog-fade-enter-active,
+.dialog-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.dialog-fade-enter-from,
+.dialog-fade-leave-to {
+  opacity: 0;
+}
+</style>


### PR DESCRIPTION
## Summary
- extract a reusable `AppDialog` shell that centralizes the overlay, layout, and shared close button handling
- update the currency selector and transfer account dialogs to render their content inside the shared dialog component
- consolidate dialog close translations across all locales and remove the duplicated keys

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dae1d89500832cad4e9a9856814639