### PR TITLE
Remove copy-all tooltip from transfer dialog

### DIFF
--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -81,10 +81,8 @@
     "description": "Send {amountWithCurrency} to one of the accounts below.",
     "copyAll": "Copy all details",
     "copyNumber": "Copy only account number",
-    "copyTooltip": "Copy to clipboard",
     "copyAllButton": "Copy transfer details",
     "copiedAllButton": "Copied to clipboard",
-    "copied": "Copied!",
     "copiedNumber": "Account number copied"
   },
   "payment": {

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -81,10 +81,8 @@
     "description": "下記のいずれかの口座へ {amountWithCurrency} をお振り込みください。",
     "copyAll": "すべての情報をコピー",
     "copyNumber": "口座番号のみコピー",
-    "copyTooltip": "クリップボードにコピー",
     "copyAllButton": "振込情報をコピー",
     "copiedAllButton": "クリップボードにコピーしました",
-    "copied": "コピーしました！",
     "copiedNumber": "口座番号のみコピーしました"
   },
   "payment": {

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -81,10 +81,8 @@
     "description": "{amountWithCurrency} 금액을 아래 계좌 중 하나로 보내 주세요.",
     "copyAll": "전체 정보 복사",
     "copyNumber": "계좌번호만 복사",
-    "copyTooltip": "클립보드로 복사",
     "copyAllButton": "이체 정보 복사",
     "copiedAllButton": "클립보드에 복사됨",
-    "copied": "복사됨!",
     "copiedNumber": "계좌번호만 복사했어요"
   },
   "payment": {

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -81,10 +81,8 @@
     "description": "请将 {amountWithCurrency} 转入下方任一账户。",
     "copyAll": "复制全部信息",
     "copyNumber": "仅复制账号",
-    "copyTooltip": "复制到剪贴板",
     "copyAllButton": "复制转账信息",
     "copiedAllButton": "已复制到剪贴板",
-    "copied": "已复制！",
     "copiedNumber": "仅复制了账号"
   },
   "payment": {

--- a/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
+++ b/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
@@ -78,24 +78,11 @@ const descriptionHtml = computed(() =>
 )
 const copyAllLabel = computed(() => i18nStore.t('transferPopup.copyAll'))
 const copyNumberLabel = computed(() => i18nStore.t('transferPopup.copyNumber'))
-const copyTooltipLabel = computed(() => i18nStore.t('transferPopup.copyTooltip'))
-const copiedLabel = computed(() => i18nStore.t('transferPopup.copied'))
 const copiedNumberLabel = computed(() => i18nStore.t('transferPopup.copiedNumber'))
 const copyAllButtonLabel = computed(() => i18nStore.t('transferPopup.copyAllButton'))
 const copiedAllButtonLabel = computed(() => i18nStore.t('transferPopup.copiedAllButton'))
 
 const getIconForBank = (bank: string) => firmIconMap[bank] ?? null
-
-const getTooltipVariant = (accountNumber: string, action: CopyAction) =>
-  isCopied(accountNumber, action) ? 'success' : 'default'
-
-const getTooltipMessage = (accountNumber: string, action: CopyAction) => {
-  if (isCopied(accountNumber, action)) {
-    return action === 'all' ? copiedLabel.value : copiedNumberLabel.value
-  }
-
-  return action === 'all' ? copyTooltipLabel.value : copyNumberLabel.value
-}
 
 const copyTransferDetails = async (account: TransferAccount) => {
   const amountText = `${formattedAmountForCopy.value}원`
@@ -176,8 +163,8 @@ watch(
                 </button>
                 <TooltipBubble
                   :visible="isTooltipVisible(account.number, 'number')"
-                  :message="getTooltipMessage(account.number, 'number')"
-                  :variant="getTooltipVariant(account.number, 'number')"
+                  :message="isCopied(account.number, 'number') ? copiedNumberLabel : copyNumberLabel"
+                  :variant="isCopied(account.number, 'number') ? 'success' : 'default'"
                 />
               </div>
             </div>
@@ -193,10 +180,6 @@ watch(
               ]"
               :aria-label="copyAllLabel"
               @click="copyTransferDetails(account)"
-              @mouseenter="setHoverState(account.number, 'all', true)"
-              @mouseleave="setHoverState(account.number, 'all', false)"
-              @focus="setHoverState(account.number, 'all', true)"
-              @blur="setHoverState(account.number, 'all', false)"
             >
               <span class="flex items-center gap-2 sm:hidden">
                 <span class="text-sm font-semibold text-white">
@@ -215,11 +198,6 @@ watch(
                 v-html="isCopied(account.number, 'all') ? successIcon : clipboardIcon"
               ></span>
             </button>
-            <TooltipBubble
-              :visible="isTooltipVisible(account.number, 'all')"
-              :message="getTooltipMessage(account.number, 'all')"
-              :variant="getTooltipVariant(account.number, 'all')"
-            />
           </div>
         </div>
       </li>


### PR DESCRIPTION
## Summary
- remove the tooltip bubble and hover handling from the copy-all control in the transfer dialog
- delete the unused copy tooltip translations from every locale file

## Testing
- npm run lint *(fails: existing lint issues in Experience.vue, Section.vue, deepLinkService.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dae98a46d4832c831d2e1d03b953b4