### PR TITLE
Rename transfer popup terminology to dialog

### DIFF
--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -21,7 +21,7 @@ const {
   isPopupVisible,
   popupContent,
   isDeepLinkChecking,
-  isTransferPopupVisible,
+  isTransferDialogVisible,
   transferAmount,
   transferAccounts,
 } = storeToRefs(paymentInteractionStore)
@@ -52,8 +52,8 @@ const onPopupConfirm = () => {
   paymentInteractionStore.closePopup()
 }
 
-const onCloseTransferPopup = () => {
-  paymentInteractionStore.closeTransferPopup()
+const onCloseTransferDialog = () => {
+  paymentInteractionStore.closeTransferDialog()
 }
 </script>
 
@@ -85,10 +85,10 @@ const onCloseTransferPopup = () => {
       @confirm="onPopupConfirm"
     />
     <TransferAccountsDialog
-      :visible="isTransferPopupVisible"
+      :visible="isTransferDialogVisible"
       :accounts="transferAccounts"
       :amount="transferAmount"
-      @close="onCloseTransferPopup"
+      @close="onCloseTransferDialog"
     />
     <LoadingOverlay :visible="isDeepLinkChecking" :message="i18nStore.t('loading.deepLink')" />
   </div>

--- a/frontend/src/payments/stores/paymentInteraction.store.ts
+++ b/frontend/src/payments/stores/paymentInteraction.store.ts
@@ -23,9 +23,9 @@ const buildWorkflowContext = (
   paymentInfoStore: ReturnType<typeof usePaymentInfoStore>,
   showPopup: (state: PopupState) => void,
   setDeepLinkChecking: (value: boolean) => void,
-  openTransferPopup: () => void,
+  openTransferDialog: () => void,
 ): PaymentActionContext => ({
-  openTransferPopup,
+  openTransferDialog,
   openMethodUrl: (method: PaymentMethod, currency: string | null) => {
     const url = paymentStore.getUrlForMethod(method.id, currency ?? undefined)
     openUrlInNewTab(url)
@@ -60,7 +60,7 @@ export const usePaymentInteractionStore = defineStore('payment-interaction', () 
 
   const popupState = ref<PopupState | null>(null)
   const isDeepLinkChecking = ref(false)
-  const isTransferPopupVisible = ref(false)
+  const isTransferDialogVisible = ref(false)
 
   const transferAmount = computed(() => paymentInfoStore.transferInfo?.amount.krw ?? 0)
   const transferAccounts = computed(() => paymentInfoStore.transferInfo?.account ?? [])
@@ -98,12 +98,12 @@ export const usePaymentInteractionStore = defineStore('payment-interaction', () 
     popupState.value = state
   }
 
-  const openTransferPopup = () => {
-    isTransferPopupVisible.value = true
+  const openTransferDialog = () => {
+    isTransferDialogVisible.value = true
   }
 
-  const closeTransferPopup = () => {
-    isTransferPopupVisible.value = false
+  const closeTransferDialog = () => {
+    isTransferDialogVisible.value = false
   }
 
   const setDeepLinkChecking = (value: boolean) => {
@@ -115,7 +115,7 @@ export const usePaymentInteractionStore = defineStore('payment-interaction', () 
     paymentInfoStore,
     showPopup,
     setDeepLinkChecking,
-    openTransferPopup,
+    openTransferDialog,
   )
 
   const resolveAction = createPaymentActionResolver(workflowContext)
@@ -158,11 +158,11 @@ export const usePaymentInteractionStore = defineStore('payment-interaction', () 
     isPopupVisible,
     popupContent,
     isDeepLinkChecking,
-    isTransferPopupVisible,
+    isTransferDialogVisible,
     transferAmount,
     transferAccounts,
     closePopup,
-    closeTransferPopup,
+    closeTransferDialog,
     handleMethodSelection,
     handleCurrencySelection,
   }

--- a/frontend/src/payments/workflows/actions/transfer.ts
+++ b/frontend/src/payments/workflows/actions/transfer.ts
@@ -19,7 +19,7 @@ const runTransferWorkflow = async (context: PaymentActionContext) => {
     return
   }
 
-  context.openTransferPopup()
+  context.openTransferDialog()
 }
 
 export const createTransferAction = (context: PaymentActionContext): PaymentMethodAction => ({

--- a/frontend/src/payments/workflows/types.ts
+++ b/frontend/src/payments/workflows/types.ts
@@ -2,7 +2,7 @@ import type { PaymentMethod, DeepLinkProvider } from '@/payments/types'
 import type { KakaoPaymentInfo, TossPaymentInfo } from '@/payments/services/paymentInfoService'
 
 export type PaymentActionContext = {
-  openTransferPopup: () => void
+  openTransferDialog: () => void
   openMethodUrl: (method: PaymentMethod, currency: string | null) => void
   ensurePaymentInfoLoaded: () => Promise<boolean>
   getDeepLinkInfo: (provider: DeepLinkProvider) => TossPaymentInfo | KakaoPaymentInfo | null


### PR DESCRIPTION
## Summary
- rename the transfer popup naming to transfer dialog across payment workflows and store
- keep the transfer accounts dialog usage aligned with the new store properties

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db59ab6954832c966fc8fc85930084