### PR TITLE
Add Toss reopen option after countdown

### DIFF
--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -76,6 +76,19 @@
   "dialog": {
     "close": "Close"
   },
+  "accountInfo": {
+    "bank": "Bank",
+    "account": "Account number",
+    "amount": "Amount"
+  },
+  "tossInstruction": {
+    "title": "Send with Toss",
+    "description": "We've copied the account details you need for Toss.",
+    "copied": "Account info copied to clipboard",
+    "countdown": "Opening Toss in {seconds}s",
+    "launching": "Opening Toss...",
+    "reopen": "Reopen Toss"
+  },
   "transferPopup": {
     "title": "Bank transfer details",
     "description": "Send {amountWithCurrency} to one of the accounts below.",

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -76,6 +76,19 @@
   "dialog": {
     "close": "閉じる"
   },
+  "accountInfo": {
+    "bank": "銀行",
+    "account": "口座番号",
+    "amount": "送金金額"
+  },
+  "tossInstruction": {
+    "title": "Tossで送金",
+    "description": "Toss送金に必要な口座情報をコピーしました。",
+    "copied": "口座情報をコピーしました",
+    "countdown": "{seconds}秒後にTossを起動します",
+    "launching": "Tossを起動しています...",
+    "reopen": "Tossをもう一度開く"
+  },
   "transferPopup": {
     "title": "口座振込のご案内",
     "description": "下記のいずれかの口座へ {amountWithCurrency} をお振り込みください。",

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -76,6 +76,19 @@
   "dialog": {
     "close": "닫기"
   },
+  "accountInfo": {
+    "bank": "은행",
+    "account": "계좌번호",
+    "amount": "송금 금액"
+  },
+  "tossInstruction": {
+    "title": "토스로 송금하기",
+    "description": "토스 송금에 필요한 계좌 정보를 복사해 두었어요.",
+    "copied": "계좌 정보가 복사되었어요",
+    "countdown": "{seconds}초 후 토스를 실행할게요",
+    "launching": "토스를 실행하는 중...",
+    "reopen": "다시열기"
+  },
   "transferPopup": {
     "title": "계좌이체 정보",
     "description": "{amountWithCurrency} 금액을 아래 계좌 중 하나로 보내 주세요.",

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -76,6 +76,19 @@
   "dialog": {
     "close": "关闭"
   },
+  "accountInfo": {
+    "bank": "银行",
+    "account": "账号",
+    "amount": "汇款金额"
+  },
+  "tossInstruction": {
+    "title": "使用 Toss 转账",
+    "description": "已为 Toss 转账复制所需的账户信息。",
+    "copied": "账户信息已复制",
+    "countdown": "{seconds} 秒后打开 Toss",
+    "launching": "正在打开 Toss...",
+    "reopen": "重新打开 Toss"
+  },
   "transferPopup": {
     "title": "银行转账信息",
     "description": "请将 {amountWithCurrency} 转入下方任一账户。",

--- a/frontend/src/payments/components/AccountInfoCard.vue
+++ b/frontend/src/payments/components/AccountInfoCard.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+
+import { useI18nStore } from '@/localization/store'
+
+interface Props {
+  bankName: string
+  accountNo: string
+  amount: number
+}
+
+const props = defineProps<Props>()
+
+const i18nStore = useI18nStore()
+const { locale } = storeToRefs(i18nStore)
+
+const bankLabel = computed(() => i18nStore.t('accountInfo.bank'))
+const accountLabel = computed(() => i18nStore.t('accountInfo.account'))
+const amountLabel = computed(() => i18nStore.t('accountInfo.amount'))
+
+const firmIcons = import.meta.glob('@icons/firms/*.svg', {
+  eager: true,
+  import: 'default',
+}) as Record<string, string>
+
+const firmIconMap = Object.entries(firmIcons).reduce<Record<string, string>>((acc, [path, value]) => {
+  const segments = path.split('/')
+  const filename = segments[segments.length - 1] ?? ''
+  const name = filename.replace('.svg', '')
+  acc[name] = value
+  return acc
+}, {})
+
+const normalizedBankName = computed(() => props.bankName.trim())
+
+const bankIcon = computed(() => {
+  const direct = firmIconMap[normalizedBankName.value]
+  if (direct) {
+    return direct
+  }
+
+  const compact = normalizedBankName.value.replace(/\s+/g, '')
+  return firmIconMap[compact] ?? null
+})
+
+const bankMonogram = computed(() => {
+  const trimmed = normalizedBankName.value
+  if (!trimmed) {
+    return ''
+  }
+
+  const compact = trimmed.replace(/[^\p{L}\p{N}]/gu, '')
+  const source = compact || trimmed
+  const preview = source.slice(0, 2)
+
+  return /[A-Za-z]/.test(preview) ? preview.toUpperCase() : preview
+})
+
+const localeNumberFormats: Record<string, string> = {
+  en: 'en-US',
+  ko: 'ko-KR',
+  ja: 'ja-JP',
+  zh: 'zh-CN',
+}
+
+const formattedAmount = computed(() =>
+  new Intl.NumberFormat(localeNumberFormats[locale.value] ?? 'en-US', {
+    style: 'currency',
+    currency: 'KRW',
+    maximumFractionDigits: 0,
+  }).format(props.amount),
+)
+</script>
+
+<template>
+  <article class="relative overflow-hidden rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-md">
+    <div class="flex flex-col items-center gap-6">
+      <div class="flex flex-col items-center gap-3 text-center">
+        <div
+          class="flex h-16 w-16 items-center justify-center rounded-2xl bg-roadshop-highlight/60 shadow-inner"
+          aria-hidden="true"
+        >
+          <img v-if="bankIcon" :src="bankIcon" :alt="props.bankName" class="h-10 w-10" />
+          <span v-else class="text-lg font-semibold text-roadshop-primary">{{ bankMonogram }}</span>
+        </div>
+        <div>
+          <p class="text-xs font-medium uppercase tracking-[0.2em] text-slate-400">{{ bankLabel }}</p>
+          <p class="mt-1 text-lg font-semibold text-roadshop-primary">{{ props.bankName }}</p>
+        </div>
+      </div>
+
+      <div class="grid w-full gap-3 sm:grid-cols-2">
+        <div class="rounded-2xl border border-roadshop-highlight/70 bg-roadshop-highlight/40 p-4 text-center sm:text-left">
+          <p class="text-[0.65rem] font-semibold uppercase tracking-wider text-slate-500">
+            {{ accountLabel }}
+          </p>
+          <p class="mt-2 font-mono text-lg text-roadshop-primary">{{ props.accountNo }}</p>
+        </div>
+        <div class="rounded-2xl border border-roadshop-highlight/40 bg-roadshop-highlight/20 p-4 text-center sm:text-left">
+          <p class="text-[0.65rem] font-semibold uppercase tracking-wider text-slate-500">
+            {{ amountLabel }}
+          </p>
+          <p class="mt-2 text-lg font-semibold text-roadshop-primary">{{ formattedAmount }}</p>
+        </div>
+      </div>
+    </div>
+  </article>
+</template>

--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -7,6 +7,7 @@ import LoadingOverlay from '@/shared/components/LoadingOverlay.vue'
 import CurrencySelectorDialog from '@/payments/components/CurrencySelectorDialog.vue'
 import Section from '@/payments/components/Section.vue'
 import TransferAccountsDialog from '@/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue'
+import TossInstructionDialog from '@/payments/components/TossInstructionDialog.vue'
 import { useLocalizedSections } from '@/payments/composables/useLocalizedSections'
 import { usePaymentStore } from '@/payments/stores/payment.store'
 import { usePaymentInteractionStore } from '@/payments/stores/paymentInteraction.store'
@@ -24,6 +25,10 @@ const {
   isTransferDialogVisible,
   transferAmount,
   transferAccounts,
+  isTossInstructionDialogVisible,
+  tossInstructionCountdown,
+  hasCopiedTossAccountInfo,
+  tossAccountInfo,
 } = storeToRefs(paymentInteractionStore)
 
 const { sections } = useLocalizedSections()
@@ -54,6 +59,14 @@ const onPopupConfirm = () => {
 
 const onCloseTransferDialog = () => {
   paymentInteractionStore.closeTransferDialog()
+}
+
+const onCloseTossInstructionDialog = () => {
+  paymentInteractionStore.closeTossInstructionDialog()
+}
+
+const onReopenTossInstructionDialog = () => {
+  paymentInteractionStore.relaunchTossDeepLink()
 }
 </script>
 
@@ -89,6 +102,14 @@ const onCloseTransferDialog = () => {
       :accounts="transferAccounts"
       :amount="transferAmount"
       @close="onCloseTransferDialog"
+    />
+    <TossInstructionDialog
+      :visible="isTossInstructionDialogVisible"
+      :info="tossAccountInfo"
+      :countdown="tossInstructionCountdown"
+      :copied="hasCopiedTossAccountInfo"
+      @close="onCloseTossInstructionDialog"
+      @reopen="onReopenTossInstructionDialog"
     />
     <LoadingOverlay :visible="isDeepLinkChecking" :message="i18nStore.t('loading.deepLink')" />
   </div>

--- a/frontend/src/payments/components/TossInstructionDialog.vue
+++ b/frontend/src/payments/components/TossInstructionDialog.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { useI18nStore } from '@/localization/store'
+import AccountInfoCard from '@/payments/components/AccountInfoCard.vue'
+import AppDialog from '@/shared/components/AppDialog.vue'
+import type { TossPaymentInfo } from '@/payments/services/paymentInfoService'
+
+interface Props {
+  visible: boolean
+  info: TossPaymentInfo | null
+  countdown: number
+  copied: boolean
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  close: []
+  reopen: []
+}>()
+
+const i18nStore = useI18nStore()
+
+const title = computed(() => i18nStore.t('tossInstruction.title'))
+const description = computed(() => i18nStore.t('tossInstruction.description'))
+const copiedLabel = computed(() => i18nStore.t('tossInstruction.copied'))
+const countdownLabel = computed(() => {
+  if (props.countdown > 0) {
+    return i18nStore.t('tossInstruction.countdown').replace(
+      '{seconds}',
+      props.countdown.toString(),
+    )
+  }
+
+  return i18nStore.t('tossInstruction.launching')
+})
+const reopenLabel = computed(() => i18nStore.t('tossInstruction.reopen'))
+
+const onClose = () => {
+  emit('close')
+}
+
+const onReopen = () => {
+  emit('reopen')
+}
+</script>
+
+<template>
+  <AppDialog
+    :visible="props.visible"
+    :title="title"
+    :description="description"
+    close-alignment="end"
+    @close="onClose"
+  >
+    <div class="flex flex-col gap-4">
+      <p v-if="props.copied" class="text-xs font-medium text-emerald-600">
+        {{ copiedLabel }}
+      </p>
+      <AccountInfoCard
+        v-if="props.info"
+        :bank-name="props.info.bankName"
+        :account-no="props.info.accountNo"
+        :amount="props.info.amount.krw"
+      />
+      <div class="rounded-2xl bg-roadshop-highlight/70 px-4 py-3">
+        <p v-if="props.countdown > 0" class="text-sm font-semibold text-roadshop-primary">
+          {{ countdownLabel }}
+        </p>
+        <button
+          v-else
+          type="button"
+          class="text-sm font-semibold text-roadshop-primary underline underline-offset-4"
+          @click="onReopen"
+        >
+          {{ reopenLabel }}
+        </button>
+      </div>
+    </div>
+  </AppDialog>
+</template>

--- a/frontend/src/payments/stores/paymentInteraction.store.ts
+++ b/frontend/src/payments/stores/paymentInteraction.store.ts
@@ -10,6 +10,7 @@ import { createPaymentActionResolver } from '@/payments/workflows/createPaymentA
 import type { PaymentActionContext } from '@/payments/workflows/types'
 import { isMobileDevice } from '@/shared/utils/device'
 import { openUrlInNewTab } from '@/shared/utils/navigation'
+import { copyText } from '@/shared/utils/clipboard'
 
 type PopupType = 'not-mobile' | 'not-installed'
 
@@ -19,6 +20,10 @@ const buildWorkflowContext = (
   showPopup: (type: PopupType, provider: DeepLinkProvider) => void,
   setDeepLinkChecking: (value: boolean) => void,
   openTransferDialog: () => void,
+  copyTossAccountInfo: () => Promise<boolean>,
+  setTossDeepLinkUrl: (url: string | null) => void,
+  showTossInstructionDialog: (seconds: number) => Promise<void>,
+  completeTossInstructionDialog: () => void,
 ): PaymentActionContext => ({
   openTransferDialog,
   openMethodUrl: (method: PaymentMethod, currency: string | null) => {
@@ -41,6 +46,10 @@ const buildWorkflowContext = (
   },
   isMobileDevice,
   openUrlInNewTab,
+  copyTossAccountInfo,
+  setTossDeepLinkUrl,
+  showTossInstructionDialog,
+  completeTossInstructionDialog,
 })
 
 export const usePaymentInteractionStore = defineStore('payment-interaction', () => {
@@ -48,6 +57,7 @@ export const usePaymentInteractionStore = defineStore('payment-interaction', () 
   const paymentInfoStore = usePaymentInfoStore()
   const i18nStore = useI18nStore()
   const { isCurrencySelectorOpen, selectedCurrency, selectedMethod } = storeToRefs(paymentStore)
+  const { tossInfo } = storeToRefs(paymentInfoStore)
 
   void paymentInfoStore.ensureLoaded()
 
@@ -58,6 +68,12 @@ export const usePaymentInteractionStore = defineStore('payment-interaction', () 
   } | null>(null)
   const isDeepLinkChecking = ref(false)
   const isTransferDialogVisible = ref(false)
+  const isTossInstructionDialogVisible = ref(false)
+  const tossInstructionCountdown = ref(0)
+  const hasCopiedTossAccountInfo = ref(false)
+  const tossDeepLinkUrl = ref<string | null>(null)
+  let tossCountdownTimer: ReturnType<typeof setInterval> | null = null
+  let tossCountdownResolver: (() => void) | null = null
 
   const transferAmount = computed(() => paymentInfoStore.transferInfo?.amount.krw ?? 0)
   const transferAccounts = computed(() => paymentInfoStore.transferInfo?.account ?? [])
@@ -91,12 +107,120 @@ export const usePaymentInteractionStore = defineStore('payment-interaction', () 
     isDeepLinkChecking.value = value
   }
 
+  const copyTossAccountInfo = async (): Promise<boolean> => {
+    if (!tossInfo.value) {
+      return false
+    }
+
+    const amountText = new Intl.NumberFormat('ko-KR').format(tossInfo.value.amount.krw)
+    const payload = `${tossInfo.value.bankName} ${tossInfo.value.accountNo} ${amountText}원`
+    const success = await copyText(payload)
+
+    hasCopiedTossAccountInfo.value = success
+
+    return success
+  }
+
+  const showTossInstructionDialog = (seconds: number): Promise<void> => {
+    if (!tossInfo.value) {
+      return Promise.resolve()
+    }
+
+    if (tossCountdownTimer) {
+      clearInterval(tossCountdownTimer)
+      tossCountdownTimer = null
+    }
+
+    tossInstructionCountdown.value = Math.max(0, seconds)
+    isTossInstructionDialogVisible.value = true
+
+    if (tossInstructionCountdown.value === 0) {
+      return Promise.resolve()
+    }
+
+    return new Promise<void>((resolve) => {
+      tossCountdownResolver = resolve
+      tossCountdownTimer = setInterval(() => {
+        if (tossInstructionCountdown.value <= 1) {
+          if (tossCountdownTimer) {
+            clearInterval(tossCountdownTimer)
+            tossCountdownTimer = null
+          }
+
+          tossInstructionCountdown.value = 0
+
+          if (tossCountdownResolver) {
+            const countdownResolve = tossCountdownResolver
+            tossCountdownResolver = null
+            countdownResolve()
+          }
+
+          return
+        }
+
+        tossInstructionCountdown.value -= 1
+      }, 1000)
+    })
+  }
+
+  const closeTossInstructionDialog = () => {
+    if (tossCountdownTimer) {
+      clearInterval(tossCountdownTimer)
+      tossCountdownTimer = null
+    }
+
+    if (tossCountdownResolver) {
+      const resolve = tossCountdownResolver
+      tossCountdownResolver = null
+      resolve()
+    }
+
+    isTossInstructionDialogVisible.value = false
+    tossInstructionCountdown.value = 0
+    hasCopiedTossAccountInfo.value = false
+    tossDeepLinkUrl.value = null
+  }
+
+  const completeTossInstructionDialog = () => {
+    if (tossCountdownTimer) {
+      clearInterval(tossCountdownTimer)
+      tossCountdownTimer = null
+    }
+
+    tossCountdownResolver = null
+    tossInstructionCountdown.value = 0
+  }
+
+  const setTossDeepLinkUrl = (url: string | null) => {
+    tossDeepLinkUrl.value = url
+  }
+
+  const relaunchTossDeepLink = () => {
+    if (!tossDeepLinkUrl.value) {
+      return
+    }
+
+    if (isMobileDevice()) {
+      if (typeof window !== 'undefined') {
+        window.location.href = tossDeepLinkUrl.value
+      }
+
+      return
+    }
+
+    openUrlInNewTab(tossDeepLinkUrl.value)
+  }
+
   const workflowContext = buildWorkflowContext(
     paymentStore,
     paymentInfoStore,
     showPopup,
     setDeepLinkChecking,
     openTransferDialog,
+    copyTossAccountInfo,
+    setTossDeepLinkUrl,
+    showTossInstructionDialog,
+    completeTossInstructionDialog,
   )
 
   const resolveAction = createPaymentActionResolver(workflowContext)
@@ -142,8 +266,14 @@ export const usePaymentInteractionStore = defineStore('payment-interaction', () 
     isTransferDialogVisible,
     transferAmount,
     transferAccounts,
+    isTossInstructionDialogVisible,
+    tossInstructionCountdown,
+    hasCopiedTossAccountInfo,
+    tossAccountInfo: tossInfo,
+    relaunchTossDeepLink,
     closePopup,
     closeTransferDialog,
+    closeTossInstructionDialog,
     handleMethodSelection,
     handleCurrencySelection,
   }

--- a/frontend/src/payments/workflows/actions/toss.ts
+++ b/frontend/src/payments/workflows/actions/toss.ts
@@ -53,8 +53,14 @@ const runTossWorkflow = async (context: PaymentActionContext) => {
   const deepLink = await ensureTossDeepLink(context)
 
   if (!deepLink) {
+    context.setTossDeepLinkUrl(null)
     return
   }
+
+  context.setTossDeepLinkUrl(deepLink)
+
+  await context.copyTossAccountInfo()
+  await context.showTossInstructionDialog(5)
 
   const isMobile = context.isMobileDevice()
 
@@ -62,7 +68,11 @@ const runTossWorkflow = async (context: PaymentActionContext) => {
     context.showDeepLinkPopup('not-mobile', 'toss')
   }
 
-  await launchTossDeepLink(context, deepLink, { checkInstallation: isMobile })
+  try {
+    await launchTossDeepLink(context, deepLink, { checkInstallation: isMobile })
+  } finally {
+    context.completeTossInstructionDialog()
+  }
 
   if (!isMobile) {
     context.openUrlInNewTab(deepLink)

--- a/frontend/src/payments/workflows/types.ts
+++ b/frontend/src/payments/workflows/types.ts
@@ -12,6 +12,10 @@ export type PaymentActionContext = {
   navigateToDeepLink: (url: string) => boolean
   isMobileDevice: () => boolean
   openUrlInNewTab: (url: string | null) => void
+  copyTossAccountInfo: () => Promise<boolean>
+  setTossDeepLinkUrl: (url: string | null) => void
+  showTossInstructionDialog: (seconds: number) => Promise<void>
+  completeTossInstructionDialog: () => void
 }
 
 export type PaymentMethodAction = {


### PR DESCRIPTION
## Summary
- show an underlined reopen action after the Toss countdown ends
- keep the Toss instructions dialog open, persist the deep link, and allow relaunching the app
- localize the new reopen label across all supported languages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db7c49b660832cb1f40596391693fc