### PR TITLE
Revise Toss account info card layout

### DIFF
--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -76,6 +76,19 @@
   "dialog": {
     "close": "Close"
   },
+  "accountInfo": {
+    "bank": "Bank",
+    "account": "Account number",
+    "holder": "Account holder"
+  },
+  "tossInstruction": {
+    "title": "Send with Toss",
+    "description": "We've copied the account details you need for Toss.",
+    "copied": "Account info copied to clipboard",
+    "countdown": "Opening Toss in {seconds}s",
+    "launching": "Opening Toss...",
+    "reopen": "Reopen Toss"
+  },
   "transferPopup": {
     "title": "Bank transfer details",
     "description": "Send {amountWithCurrency} to one of the accounts below.",

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -76,6 +76,19 @@
   "dialog": {
     "close": "閉じる"
   },
+  "accountInfo": {
+    "bank": "銀行",
+    "account": "口座番号",
+    "holder": "口座名義"
+  },
+  "tossInstruction": {
+    "title": "Tossで送金",
+    "description": "Toss送金に必要な口座情報をコピーしました。",
+    "copied": "口座情報をコピーしました",
+    "countdown": "{seconds}秒後にTossを起動します",
+    "launching": "Tossを起動しています...",
+    "reopen": "もう一度開く"
+  },
   "transferPopup": {
     "title": "口座振込のご案内",
     "description": "下記のいずれかの口座へ {amountWithCurrency} をお振り込みください。",

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -76,6 +76,19 @@
   "dialog": {
     "close": "닫기"
   },
+  "accountInfo": {
+    "bank": "은행",
+    "account": "계좌번호",
+    "holder": "계좌주"
+  },
+  "tossInstruction": {
+    "title": "토스로 송금하기",
+    "description": "토스 송금에 필요한 계좌 정보를 복사해 두었어요.",
+    "copied": "계좌 정보가 복사되었어요",
+    "countdown": "{seconds}초 후 토스를 실행할게요",
+    "launching": "토스를 실행하는 중...",
+    "reopen": "다시열기"
+  },
   "transferPopup": {
     "title": "계좌이체 정보",
     "description": "{amountWithCurrency} 금액을 아래 계좌 중 하나로 보내 주세요.",

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -76,6 +76,19 @@
   "dialog": {
     "close": "关闭"
   },
+  "accountInfo": {
+    "bank": "银行",
+    "account": "账号",
+    "holder": "账户名"
+  },
+  "tossInstruction": {
+    "title": "使用 Toss 转账",
+    "description": "已为 Toss 转账复制所需的账户信息。",
+    "copied": "账户信息已复制",
+    "countdown": "{seconds} 秒后打开 Toss",
+    "launching": "正在打开 Toss...",
+    "reopen": "重新打开"
+  },
   "transferPopup": {
     "title": "银行转账信息",
     "description": "请将 {amountWithCurrency} 转入下方任一账户。",

--- a/frontend/src/payments/components/AccountInfoCard.vue
+++ b/frontend/src/payments/components/AccountInfoCard.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface Props {
+  bankName: string
+  accountNo: string
+  accountHolder: string
+}
+
+const props = defineProps<Props>()
+
+const firmIcons = import.meta.glob('@icons/firms/*.svg', {
+  eager: true,
+  import: 'default',
+}) as Record<string, string>
+
+const firmIconMap = Object.entries(firmIcons).reduce<Record<string, string>>((acc, [path, value]) => {
+  const segments = path.split('/')
+  const filename = segments[segments.length - 1] ?? ''
+  const name = filename.replace('.svg', '')
+  acc[name] = value
+  return acc
+}, {})
+
+const normalizedBankName = computed(() => props.bankName.trim())
+
+const bankIcon = computed(() => {
+  const direct = firmIconMap[normalizedBankName.value]
+  if (direct) {
+    return direct
+  }
+
+  const compact = normalizedBankName.value.replace(/\s+/g, '')
+  return firmIconMap[compact] ?? null
+})
+
+const bankMonogram = computed(() => {
+  const trimmed = normalizedBankName.value
+  if (!trimmed) {
+    return ''
+  }
+
+  const compact = trimmed.replace(/[^\p{L}\p{N}]/gu, '')
+  const source = compact || trimmed
+  const preview = source.slice(0, 2)
+
+  return /[A-Za-z]/.test(preview) ? preview.toUpperCase() : preview
+})
+</script>
+
+<template>
+  <article class="relative overflow-hidden rounded-3xl border border-slate-200 bg-white/95 p-8 shadow-md">
+    <div class="flex flex-col items-center gap-7 text-center">
+      <div class="flex flex-col items-center gap-5">
+        <div
+          class="flex h-20 w-20 items-center justify-center rounded-3xl bg-roadshop-highlight/60 shadow-inner"
+          aria-hidden="true"
+        >
+          <img v-if="bankIcon" :src="bankIcon" :alt="props.bankName" class="h-14 w-14" />
+          <span v-else class="text-2xl font-semibold text-roadshop-primary">{{ bankMonogram }}</span>
+        </div>
+        <div>
+          <p class="text-2xl font-semibold text-roadshop-primary">
+            {{ props.bankName }}
+            <span class="ml-2 text-lg font-medium text-roadshop-primary/80">({{ props.accountHolder }})</span>
+          </p>
+          <p class="mt-3 font-mono text-xl tracking-wider text-slate-700">{{ props.accountNo }}</p>
+        </div>
+      </div>
+    </div>
+  </article>
+</template>

--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -7,6 +7,7 @@ import LoadingOverlay from '@/shared/components/LoadingOverlay.vue'
 import CurrencySelectorDialog from '@/payments/components/CurrencySelectorDialog.vue'
 import Section from '@/payments/components/Section.vue'
 import TransferAccountsDialog from '@/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue'
+import TossInstructionDialog from '@/payments/components/TossInstructionDialog.vue'
 import { useLocalizedSections } from '@/payments/composables/useLocalizedSections'
 import { usePaymentStore } from '@/payments/stores/payment.store'
 import { usePaymentInteractionStore } from '@/payments/stores/paymentInteraction.store'
@@ -24,6 +25,10 @@ const {
   isTransferDialogVisible,
   transferAmount,
   transferAccounts,
+  isTossInstructionDialogVisible,
+  tossInstructionCountdown,
+  hasCopiedTossAccountInfo,
+  tossAccountInfo,
 } = storeToRefs(paymentInteractionStore)
 
 const { sections } = useLocalizedSections()
@@ -54,6 +59,14 @@ const onPopupConfirm = () => {
 
 const onCloseTransferDialog = () => {
   paymentInteractionStore.closeTransferDialog()
+}
+
+const onCloseTossInstructionDialog = () => {
+  paymentInteractionStore.closeTossInstructionDialog()
+}
+
+const onReopenTossInstructionDialog = () => {
+  void paymentInteractionStore.reopenTossDeepLink()
 }
 </script>
 
@@ -89,6 +102,14 @@ const onCloseTransferDialog = () => {
       :accounts="transferAccounts"
       :amount="transferAmount"
       @close="onCloseTransferDialog"
+    />
+    <TossInstructionDialog
+      :visible="isTossInstructionDialogVisible"
+      :info="tossAccountInfo"
+      :countdown="tossInstructionCountdown"
+      :copied="hasCopiedTossAccountInfo"
+      @close="onCloseTossInstructionDialog"
+      @reopen="onReopenTossInstructionDialog"
     />
     <LoadingOverlay :visible="isDeepLinkChecking" :message="i18nStore.t('loading.deepLink')" />
   </div>

--- a/frontend/src/payments/components/TossInstructionDialog.vue
+++ b/frontend/src/payments/components/TossInstructionDialog.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { useI18nStore } from '@/localization/store'
+import AccountInfoCard from '@/payments/components/AccountInfoCard.vue'
+import AppDialog from '@/shared/components/AppDialog.vue'
+import type { TossPaymentInfo } from '@/payments/services/paymentInfoService'
+
+interface Props {
+  visible: boolean
+  info: TossPaymentInfo | null
+  countdown: number
+  copied: boolean
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  close: []
+  reopen: []
+}>()
+
+const i18nStore = useI18nStore()
+
+const title = computed(() => i18nStore.t('tossInstruction.title'))
+const description = computed(() => i18nStore.t('tossInstruction.description'))
+const copiedLabel = computed(() => i18nStore.t('tossInstruction.copied'))
+const countdownLabel = computed(() => {
+  if (props.countdown > 0) {
+    return i18nStore.t('tossInstruction.countdown').replace(
+      '{seconds}',
+      props.countdown.toString(),
+    )
+  }
+
+  return ''
+})
+
+const reopenLabel = computed(() => i18nStore.t('tossInstruction.reopen'))
+const isCountingDown = computed(() => props.countdown > 0)
+
+const onClose = () => {
+  emit('close')
+}
+
+const onReopen = () => {
+  emit('reopen')
+}
+</script>
+
+<template>
+  <AppDialog
+    :visible="props.visible"
+    :title="title"
+    :description="description"
+    close-alignment="end"
+    @close="onClose"
+  >
+    <div class="flex flex-col gap-4">
+      <p v-if="props.copied" class="text-xs font-medium text-emerald-600">
+        {{ copiedLabel }}
+      </p>
+      <AccountInfoCard
+        v-if="props.info"
+        :bank-name="props.info.bankName"
+        :account-no="props.info.accountNo"
+        :account-holder="props.info.accountHolder"
+      />
+      <div
+        class="flex items-center justify-center rounded-2xl bg-roadshop-highlight/70 px-4 py-3"
+      >
+        <p v-if="isCountingDown" class="text-sm font-semibold text-roadshop-primary">
+          {{ countdownLabel }}
+        </p>
+        <button
+          v-else
+          type="button"
+          class="text-sm font-semibold text-roadshop-primary underline underline-offset-2"
+          @click="onReopen"
+        >
+          {{ reopenLabel }}
+        </button>
+      </div>
+    </div>
+  </AppDialog>
+</template>

--- a/frontend/src/payments/data/info.json
+++ b/frontend/src/payments/data/info.json
@@ -4,7 +4,8 @@
       "krw": 10000
     },
     "bankName": "IBK기업",
-    "accountNo": "02906382504024"
+    "accountNo": "02906382504024",
+    "accountHolder": "강일준"
   },
   "kakao": {
     "amount": {

--- a/frontend/src/payments/services/paymentInfoService.ts
+++ b/frontend/src/payments/services/paymentInfoService.ts
@@ -19,6 +19,7 @@ export type TossPaymentInfo = {
   amount: AmountKRW
   bankName: string
   accountNo: string
+  accountHolder: string
 }
 
 export type KakaoPaymentInfo = {

--- a/frontend/src/payments/workflows/actions/toss.ts
+++ b/frontend/src/payments/workflows/actions/toss.ts
@@ -52,9 +52,16 @@ const launchTossDeepLink = async (
 const runTossWorkflow = async (context: PaymentActionContext) => {
   const deepLink = await ensureTossDeepLink(context)
 
+  context.setTossDeepLinkUrl(null)
+
   if (!deepLink) {
     return
   }
+
+  context.setTossDeepLinkUrl(deepLink)
+
+  await context.copyTossAccountInfo()
+  await context.showTossInstructionDialog(5)
 
   const isMobile = context.isMobileDevice()
 
@@ -62,7 +69,11 @@ const runTossWorkflow = async (context: PaymentActionContext) => {
     context.showDeepLinkPopup('not-mobile', 'toss')
   }
 
-  await launchTossDeepLink(context, deepLink, { checkInstallation: isMobile })
+  try {
+    await launchTossDeepLink(context, deepLink, { checkInstallation: isMobile })
+  } finally {
+    context.completeTossInstructionDialog()
+  }
 
   if (!isMobile) {
     context.openUrlInNewTab(deepLink)

--- a/frontend/src/payments/workflows/types.ts
+++ b/frontend/src/payments/workflows/types.ts
@@ -12,6 +12,10 @@ export type PaymentActionContext = {
   navigateToDeepLink: (url: string) => boolean
   isMobileDevice: () => boolean
   openUrlInNewTab: (url: string | null) => void
+  copyTossAccountInfo: () => Promise<boolean>
+  showTossInstructionDialog: (seconds: number) => Promise<void>
+  completeTossInstructionDialog: () => void
+  setTossDeepLinkUrl: (url: string | null) => void
 }
 
 export type PaymentMethodAction = {


### PR DESCRIPTION
## Summary
- enlarge the Toss bank icon and simplify the account card around the bank identity
- show the bank name with the account holder in parentheses and move the account number to its own line

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db7c49b660832cb1f40596391693fc