### PR TITLE
Update Toss reopen localization labels

### DIFF
--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -87,7 +87,7 @@
     "copied": "口座情報をコピーしました",
     "countdown": "{seconds}秒後にTossを起動します",
     "launching": "Tossを起動しています...",
-    "reopen": "もう一度開く"
+    "reopen": "Tossをもう一度開く"
   },
   "transferPopup": {
     "title": "口座振込のご案内",

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -87,7 +87,7 @@
     "copied": "계좌 정보가 복사되었어요",
     "countdown": "{seconds}초 후 토스를 실행할게요",
     "launching": "토스를 실행하는 중...",
-    "reopen": "다시열기"
+    "reopen": "토스 다시열기"
   },
   "transferPopup": {
     "title": "계좌이체 정보",

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -87,7 +87,7 @@
     "copied": "账户信息已复制",
     "countdown": "{seconds} 秒后打开 Toss",
     "launching": "正在打开 Toss...",
-    "reopen": "重新打开"
+    "reopen": "重新打开 Toss"
   },
   "transferPopup": {
     "title": "银行转账信息",


### PR DESCRIPTION
## Summary
- update the Toss instruction dialog reopen copy in Korean, Japanese, and Chinese locales to include the Toss brand

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db946d7ec4832c83198e29ffb44bb7