### PR TITLE
Handle Toss instruction countdown interactions

### DIFF
--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -68,6 +68,10 @@ const onCloseTossInstructionDialog = () => {
 const onReopenTossInstructionDialog = () => {
   void paymentInteractionStore.reopenTossDeepLink()
 }
+
+const onLaunchTossInstructionDialog = () => {
+  paymentInteractionStore.completeTossInstructionCountdown()
+}
 </script>
 
 <template>
@@ -110,6 +114,7 @@ const onReopenTossInstructionDialog = () => {
       :countdown="tossInstructionCountdown"
       :copied="hasCopiedTossAccountInfo"
       @close="onCloseTossInstructionDialog"
+      @launch-now="onLaunchTossInstructionDialog"
       @reopen="onReopenTossInstructionDialog"
     />
     <LoadingOverlay :visible="isDeepLinkChecking" :message="i18nStore.t('loading.deepLink')" />

--- a/frontend/src/payments/components/TossInstructionDialog.vue
+++ b/frontend/src/payments/components/TossInstructionDialog.vue
@@ -16,8 +16,9 @@ interface Props {
 const props = defineProps<Props>()
 
 const emit = defineEmits<{
-  close: []
-  reopen: []
+  (event: 'close'): void
+  (event: 'reopen'): void
+  (event: 'launch-now'): void
 }>()
 
 const i18nStore = useI18nStore()
@@ -46,6 +47,10 @@ const onClose = () => {
 const onReopen = () => {
   emit('reopen')
 }
+
+const onLaunchNow = () => {
+  emit('launch-now')
+}
 </script>
 
 <template>
@@ -69,9 +74,14 @@ const onReopen = () => {
       <div
         class="flex items-center justify-center"
       >
-        <p v-if="isCountingDown" class="font-semibold text-roadshop-primary">
+        <button
+          v-if="isCountingDown"
+          type="button"
+          class="font-semibold text-roadshop-primary cursor-pointer"
+          @click="onLaunchNow"
+        >
           {{ countdownLabel }}
-        </p>
+        </button>
         <button
           v-else
           type="button"

--- a/frontend/src/payments/workflows/actions/toss.ts
+++ b/frontend/src/payments/workflows/actions/toss.ts
@@ -61,7 +61,12 @@ const runTossWorkflow = async (context: PaymentActionContext) => {
   context.setTossDeepLinkUrl(deepLink)
 
   await context.copyTossAccountInfo()
-  await context.showTossInstructionDialog(5)
+  const shouldLaunch = await context.showTossInstructionDialog(5)
+
+  if (!shouldLaunch) {
+    context.completeTossInstructionDialog()
+    return
+  }
 
   const isMobile = context.isMobileDevice()
 

--- a/frontend/src/payments/workflows/types.ts
+++ b/frontend/src/payments/workflows/types.ts
@@ -13,7 +13,7 @@ export type PaymentActionContext = {
   isMobileDevice: () => boolean
   openUrlInNewTab: (url: string | null) => void
   copyTossAccountInfo: () => Promise<boolean>
-  showTossInstructionDialog: (seconds: number) => Promise<void>
+  showTossInstructionDialog: (seconds: number) => Promise<boolean>
   completeTossInstructionDialog: () => void
   setTossDeepLinkUrl: (url: string | null) => void
 }


### PR DESCRIPTION
## Summary
- prevent the Toss workflow from launching when the instruction dialog is closed before the countdown finishes
- allow users to tap the countdown text to skip the wait and launch Toss immediately
- update Toss workflow logic and store plumbing to support countdown cancellation and manual completion

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db9ea4c018832cb8eb0c9f19f19e32