### PR TITLE
Add custom actions to dialog and refresh Toss buttons

### DIFF
--- a/frontend/src/payments/components/TossInstructionDialog.vue
+++ b/frontend/src/payments/components/TossInstructionDialog.vue
@@ -26,6 +26,7 @@ const i18nStore = useI18nStore()
 const title = computed(() => i18nStore.t('tossInstruction.title'))
 const description = computed(() => i18nStore.t('tossInstruction.description'))
 const copiedLabel = computed(() => i18nStore.t('tossInstruction.copied'))
+const openLabel = computed(() => i18nStore.t('payment.toss.cta'))
 const countdownLabel = computed(() => {
   if (props.countdown > 0) {
     return i18nStore.t('tossInstruction.countdown').replace(
@@ -39,6 +40,9 @@ const countdownLabel = computed(() => {
 
 const reopenLabel = computed(() => i18nStore.t('tossInstruction.reopen'))
 const isCountingDown = computed(() => props.countdown > 0)
+const openButtonLabel = computed(() =>
+  isCountingDown.value ? openLabel.value : reopenLabel.value,
+)
 
 const onClose = () => {
   emit('close')
@@ -50,6 +54,15 @@ const onReopen = () => {
 
 const onLaunchNow = () => {
   emit('launch-now')
+}
+
+const onOpen = () => {
+  if (isCountingDown.value) {
+    onLaunchNow()
+    return
+  }
+
+  onReopen()
 }
 </script>
 
@@ -71,26 +84,23 @@ const onLaunchNow = () => {
         :account-no="props.info.accountNo"
         :account-holder="props.info.accountHolder"
       />
-      <div
-        class="flex items-center justify-center"
-      >
-        <button
-          v-if="isCountingDown"
-          type="button"
-          class="font-semibold text-roadshop-primary cursor-pointer"
-          @click="onLaunchNow"
-        >
-          {{ countdownLabel }}
-        </button>
-        <button
-          v-else
-          type="button"
-          class="font-semibold text-roadshop-primary underline underline-offset-2"
-          @click="onReopen"
-        >
-          {{ reopenLabel }}
-        </button>
-      </div>
     </div>
+    <template #actions>
+      <button
+        type="button"
+        class="w-full rounded-xl bg-roadshop-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-roadshop-accent"
+        @click="onOpen"
+      >
+        {{ openButtonLabel }}
+      </button>
+      <button
+        v-if="isCountingDown"
+        type="button"
+        class="w-full rounded-xl border border-roadshop-primary/30 px-4 py-2 text-sm font-semibold text-roadshop-primary transition hover:border-roadshop-primary/60 hover:bg-roadshop-highlight/60"
+        @click="onLaunchNow"
+      >
+        {{ countdownLabel }}
+      </button>
+    </template>
   </AppDialog>
 </template>

--- a/frontend/src/shared/components/AppDialog.vue
+++ b/frontend/src/shared/components/AppDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, useSlots } from 'vue'
 
 import { useI18nStore } from '@/localization/store'
 
@@ -29,9 +29,21 @@ const i18nStore = useI18nStore()
 
 const closeLabel = computed(() => props.closeLabel ?? i18nStore.t('dialog.close'))
 
-const footerClass = computed(() =>
-  props.closeAlignment === 'end' ? 'mt-6 flex justify-end' : 'mt-6',
-)
+const slots = useSlots()
+
+const hasActions = computed(() => Boolean(slots.actions))
+
+const footerClass = computed(() => {
+  if (hasActions.value) {
+    if (props.closeAlignment === 'end') {
+      return 'mt-6 flex flex-wrap items-center justify-end gap-2'
+    }
+
+    return 'mt-6 flex flex-col gap-2'
+  }
+
+  return props.closeAlignment === 'end' ? 'mt-6 flex justify-end' : 'mt-6'
+})
 
 const closeButtonClass = computed(() => [
   'rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-500 transition hover:bg-slate-100',
@@ -75,6 +87,7 @@ const onClose = () => {
             <slot />
           </div>
           <footer :class="footerClass">
+            <slot v-if="hasActions" name="actions" />
             <button type="button" :class="closeButtonClass" @click="onClose">
               {{ closeLabel }}
             </button>


### PR DESCRIPTION
## Summary
- add an optional actions slot to the shared dialog so flows can render extra controls
- restyle the Toss instruction dialog to surface open and countdown controls as buttons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbcb3f6d8c832c9b8b433faed9548d