### PR TITLE
Remove copied account info alert from Toss instruction dialog

### DIFF
--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -84,7 +84,6 @@
   "tossInstruction": {
     "title": "Send with Toss",
     "description": "We've copied the account details you need for Toss.",
-    "copied": "Account info copied to clipboard",
     "countdown": "Opening Toss in {seconds}s",
     "launching": "Opening Toss...",
     "reopen": "Reopen Toss"

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -84,7 +84,6 @@
   "tossInstruction": {
     "title": "Tossで送金",
     "description": "Toss送金に必要な口座情報をコピーしました。",
-    "copied": "口座情報をコピーしました",
     "countdown": "{seconds}秒後にTossを起動します",
     "launching": "Tossを起動しています...",
     "reopen": "Tossをもう一度開く"

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -84,7 +84,6 @@
   "tossInstruction": {
     "title": "토스로 송금하기",
     "description": "토스 송금에 필요한 계좌 정보를 복사해 두었어요.",
-    "copied": "계좌 정보가 복사되었어요",
     "countdown": "{seconds}초 후 토스를 실행할게요",
     "launching": "토스를 실행하는 중...",
     "reopen": "토스 다시열기"

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -84,7 +84,6 @@
   "tossInstruction": {
     "title": "使用 Toss 转账",
     "description": "已为 Toss 转账复制所需的账户信息。",
-    "copied": "账户信息已复制",
     "countdown": "{seconds} 秒后打开 Toss",
     "launching": "正在打开 Toss...",
     "reopen": "重新打开 Toss"

--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -27,7 +27,6 @@ const {
   transferAccounts,
   isTossInstructionDialogVisible,
   tossInstructionCountdown,
-  hasCopiedTossAccountInfo,
   tossAccountInfo,
 } = storeToRefs(paymentInteractionStore)
 
@@ -111,7 +110,6 @@ const onLaunchTossInstructionDialog = () => {
       :visible="isTossInstructionDialogVisible"
       :info="tossAccountInfo"
       :countdown="tossInstructionCountdown"
-      :copied="hasCopiedTossAccountInfo"
       @close="onCloseTossInstructionDialog"
       @launch-now="onLaunchTossInstructionDialog"
       @reopen="onReopenTossInstructionDialog"

--- a/frontend/src/payments/components/TossInstructionDialog.vue
+++ b/frontend/src/payments/components/TossInstructionDialog.vue
@@ -10,7 +10,6 @@ interface Props {
   visible: boolean
   info: TossPaymentInfo | null
   countdown: number
-  copied: boolean
 }
 
 const props = defineProps<Props>()
@@ -25,7 +24,6 @@ const i18nStore = useI18nStore()
 
 const title = computed(() => i18nStore.t('tossInstruction.title'))
 const description = computed(() => i18nStore.t('tossInstruction.description'))
-const copiedLabel = computed(() => i18nStore.t('tossInstruction.copied'))
 const closeLabel = computed(() => i18nStore.t('dialog.close'))
 const countdownLabel = computed(() => {
   if (props.countdown > 0) {
@@ -62,9 +60,6 @@ const onLaunchNow = () => {
     @close="onClose"
   >
     <div class="flex flex-col gap-4">
-      <p v-if="props.copied" class="text-xs font-medium text-emerald-600">
-        {{ copiedLabel }}
-      </p>
       <AccountInfoCard
         v-if="props.info"
         :bank-name="props.info.bankName"


### PR DESCRIPTION
## Summary
- remove the copied account info banner from the Toss instruction dialog
- delete the corresponding localized strings in all languages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbd3d4c1b0832ca6bb4dc6d4912a12