### PR TITLE
feat: add spinner countdown to Toss instruction dialog

### DIFF
--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -85,6 +85,7 @@
     "title": "Send with Toss",
     "description": "We've copied the account details you need for Toss.",
     "countdown": "Opening Toss in {seconds}s",
+    "launch": "Go to Toss",
     "launching": "Opening Toss...",
     "reopen": "Reopen Toss"
   },

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -85,6 +85,7 @@
     "title": "Tossで送金",
     "description": "Toss送金に必要な口座情報をコピーしました。",
     "countdown": "{seconds}秒後にTossを起動します",
+    "launch": "Tossへ移動",
     "launching": "Tossを起動しています...",
     "reopen": "Tossをもう一度開く"
   },

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -85,6 +85,7 @@
     "title": "토스로 송금하기",
     "description": "토스 송금에 필요한 계좌 정보를 복사해 두었어요.",
     "countdown": "{seconds}초 후 토스를 실행할게요",
+    "launch": "토스로 이동하기",
     "launching": "토스를 실행하는 중...",
     "reopen": "토스 다시열기"
   },

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -85,6 +85,7 @@
     "title": "使用 Toss 转账",
     "description": "已为 Toss 转账复制所需的账户信息。",
     "countdown": "{seconds} 秒后打开 Toss",
+    "launch": "前往 Toss",
     "launching": "正在打开 Toss...",
     "reopen": "重新打开 Toss"
   },

--- a/frontend/src/payments/components/TossInstructionDialog.vue
+++ b/frontend/src/payments/components/TossInstructionDialog.vue
@@ -25,18 +25,8 @@ const i18nStore = useI18nStore()
 const title = computed(() => i18nStore.t('tossInstruction.title'))
 const description = computed(() => i18nStore.t('tossInstruction.description'))
 const closeLabel = computed(() => i18nStore.t('dialog.close'))
-const countdownLabel = computed(() => {
-  if (props.countdown > 0) {
-    return i18nStore.t('tossInstruction.countdown').replace(
-      '{seconds}',
-      props.countdown.toString(),
-    )
-  }
-
-  return ''
-})
-
 const reopenLabel = computed(() => i18nStore.t('tossInstruction.reopen'))
+const launchLabel = computed(() => i18nStore.t('tossInstruction.launch'))
 const isCountingDown = computed(() => props.countdown > 0)
 
 const onClose = () => {
@@ -75,7 +65,13 @@ const onLaunchNow = () => {
           class="w-full rounded-xl bg-roadshop-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-roadshop-primary/90"
           @click="onLaunchNow"
         >
-          {{ countdownLabel }}
+          <span class="flex items-center justify-center gap-3">
+            <span class="relative flex h-7 w-7 items-center justify-center">
+              <span class="absolute inline-flex h-full w-full animate-spin rounded-full border-2 border-white/30 border-t-white"></span>
+              <span class="text-xs font-semibold leading-none">{{ props.countdown }}</span>
+            </span>
+            <span>{{ launchLabel }}</span>
+          </span>
         </button>
         <button
           v-else


### PR DESCRIPTION
## Summary
- show the Toss instruction countdown inside a spinner next to the launch label
- add localized "go to Toss" copy so the dialog button stays consistent across locales

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbe7f752e8832c9ae25b858579814c