### PR TITLE
Update Toss instruction dialog countdown UI

### DIFF
--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -84,7 +84,7 @@
   "tossInstruction": {
     "title": "Send with Toss",
     "description": "We've copied the account details you need for Toss.",
-    "countdown": "Opening Toss in {seconds}s",
+    "launchCta": "Go to Toss",
     "launching": "Opening Toss...",
     "reopen": "Reopen Toss"
   },

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -84,7 +84,7 @@
   "tossInstruction": {
     "title": "Tossで送金",
     "description": "Toss送金に必要な口座情報をコピーしました。",
-    "countdown": "{seconds}秒後にTossを起動します",
+    "launchCta": "Tossへ移動",
     "launching": "Tossを起動しています...",
     "reopen": "Tossをもう一度開く"
   },

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -84,7 +84,7 @@
   "tossInstruction": {
     "title": "토스로 송금하기",
     "description": "토스 송금에 필요한 계좌 정보를 복사해 두었어요.",
-    "countdown": "{seconds}초 후 토스를 실행할게요",
+    "launchCta": "토스로 이동하기",
     "launching": "토스를 실행하는 중...",
     "reopen": "토스 다시열기"
   },

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -84,7 +84,7 @@
   "tossInstruction": {
     "title": "使用 Toss 转账",
     "description": "已为 Toss 转账复制所需的账户信息。",
-    "countdown": "{seconds} 秒后打开 Toss",
+    "launchCta": "前往 Toss",
     "launching": "正在打开 Toss...",
     "reopen": "重新打开 Toss"
   },

--- a/frontend/src/payments/components/TossInstructionDialog.vue
+++ b/frontend/src/payments/components/TossInstructionDialog.vue
@@ -25,17 +25,7 @@ const i18nStore = useI18nStore()
 const title = computed(() => i18nStore.t('tossInstruction.title'))
 const description = computed(() => i18nStore.t('tossInstruction.description'))
 const closeLabel = computed(() => i18nStore.t('dialog.close'))
-const countdownLabel = computed(() => {
-  if (props.countdown > 0) {
-    return i18nStore.t('tossInstruction.countdown').replace(
-      '{seconds}',
-      props.countdown.toString(),
-    )
-  }
-
-  return ''
-})
-
+const launchLabel = computed(() => i18nStore.t('tossInstruction.launchCta'))
 const reopenLabel = computed(() => i18nStore.t('tossInstruction.reopen'))
 const isCountingDown = computed(() => props.countdown > 0)
 
@@ -75,7 +65,15 @@ const onLaunchNow = () => {
           class="w-full rounded-xl bg-roadshop-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-roadshop-primary/90"
           @click="onLaunchNow"
         >
-          {{ countdownLabel }}
+          <span class="flex items-center justify-center gap-2">
+            <span class="relative inline-flex h-6 w-6 items-center justify-center">
+              <span class="absolute inset-0 animate-spin rounded-full border-2 border-white/40 border-t-white"></span>
+              <span class="text-xs font-semibold leading-none text-white">
+                {{ props.countdown }}
+              </span>
+            </span>
+            <span>{{ launchLabel }}</span>
+          </span>
         </button>
         <button
           v-else


### PR DESCRIPTION
## Summary
- show the Toss countdown inside a spinner badge next to the "Go to Toss" button label
- add a reusable localization key for the new deep link call to action in all supported languages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbe7f752e8832c9ae25b858579814c