### PR TITLE
Fix Toss instruction dialog button height mismatch

### DIFF
--- a/frontend/src/payments/components/TossInstructionDialog.vue
+++ b/frontend/src/payments/components/TossInstructionDialog.vue
@@ -62,7 +62,7 @@ const onLaunchNow = () => {
         <button
           v-if="isCountingDown"
           type="button"
-          class="w-full rounded-xl bg-roadshop-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-roadshop-primary/90"
+          class="flex h-11 w-full items-center justify-center rounded-xl bg-roadshop-primary px-4 text-sm font-semibold text-white transition hover:bg-roadshop-primary/90"
           @click="onLaunchNow"
         >
           <span class="flex items-center justify-center gap-2">
@@ -78,14 +78,14 @@ const onLaunchNow = () => {
         <button
           v-else
           type="button"
-          class="w-full rounded-xl bg-roadshop-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-roadshop-primary/90"
+          class="flex h-11 w-full items-center justify-center rounded-xl bg-roadshop-primary px-4 text-sm font-semibold text-white transition hover:bg-roadshop-primary/90"
           @click="onReopen"
         >
           {{ reopenLabel }}
         </button>
         <button
           type="button"
-          class="w-full rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-500 transition hover:bg-slate-100"
+          class="flex h-11 w-full items-center justify-center rounded-xl border border-slate-200 px-4 text-sm font-medium text-slate-500 transition hover:bg-slate-100"
           @click="closeDialog()"
         >
           {{ closeLabel }}


### PR DESCRIPTION
## Summary
- enforce a consistent fixed height for the action buttons in the Toss instruction dialog to prevent mismatched button sizes

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dbeaa43924832c9dce9563e70bde61