### PR TITLE
Render Toss instruction copy with HTML bold markup

### DIFF
--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -83,7 +83,7 @@
   },
   "tossInstruction": {
     "title": "Send with Toss",
-    "description": "We've copied the account details you need for Toss.",
+    "description": "We've <strong>automatically copied</strong> the account details you need for your transfer.",
     "launchCta": "Go to Toss",
     "launching": "Opening Toss...",
     "reopen": "Reopen Toss"

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -83,7 +83,7 @@
   },
   "tossInstruction": {
     "title": "Tossで送金",
-    "description": "Toss送金に必要な口座情報をコピーしました。",
+    "description": "送金に必要な口座情報を<strong>自動でコピー</strong>しました。",
     "launchCta": "Tossへ移動",
     "launching": "Tossを起動しています...",
     "reopen": "Tossをもう一度開く"

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -83,7 +83,7 @@
   },
   "tossInstruction": {
     "title": "토스로 송금하기",
-    "description": "토스 송금에 필요한 계좌 정보를 복사해 두었어요.",
+    "description": "송금에 필요한 계좌 정보를 <strong>자동으로 복사</strong>해 두었어요.",
     "launchCta": "토스로 이동하기",
     "launching": "토스를 실행하는 중...",
     "reopen": "토스 다시열기"

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -83,7 +83,7 @@
   },
   "tossInstruction": {
     "title": "使用 Toss 转账",
-    "description": "已为 Toss 转账复制所需的账户信息。",
+    "description": "已将转账所需的账户信息<strong>自动复制</strong>好了。",
     "launchCta": "前往 Toss",
     "launching": "正在打开 Toss...",
     "reopen": "重新打开 Toss"


### PR DESCRIPTION
## Summary
- replace markdown bold with HTML <strong> tags in the Toss instruction description
- ensure automatic-copy phrasing renders with emphasis across Korean, English, Japanese, and Chinese locales

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbf290ed74832ca8d3a6065507c705