### PR TITLE
style: adjust hero language icon and cleanup translations

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "pinia": "^3.0.3",
+        "primeicons": "^7.0.0",
         "vue": "^3.5.18"
       },
       "devDependencies": {
@@ -4853,6 +4854,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/primeicons": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/primeicons/-/primeicons-7.0.0.tgz",
+      "integrity": "sha512-jK3Et9UzwzTsd6tzl2RmwrVY/b8raJ3QZLzoDACj+oTJ0oX7L9Hy+XnVwgo4QVKlKpnP/Ur13SXV/pVh4LzaDw==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "pinia": "^3.0.3",
+    "primeicons": "^7.0.0",
     "vue": "^3.5.18"
   },
   "devDependencies": {

--- a/frontend/src/app/layout/HeroSection.vue
+++ b/frontend/src/app/layout/HeroSection.vue
@@ -30,8 +30,6 @@ const highlights = computed(() => [
   },
 ])
 
-const languageLabel = computed(() => i18nStore.t('language.label'))
-
 const formatLocaleLabel = (option: { label: string; nativeLabel: string }) =>
   option.label === option.nativeLabel ? option.label : `${option.label} · ${option.nativeLabel}`
 
@@ -61,7 +59,7 @@ const onLocaleChange = async (event: Event) => {
           <label
             class="relative flex cursor-pointer items-center gap-3 rounded-full border border-roadshop-primary/10 bg-white/70 px-4 py-2 text-xs font-semibold text-roadshop-primary shadow-sm backdrop-blur"
           >
-            <span class="tracking-[0.2em] text-roadshop-accent">{{ languageLabel }}</span>
+            <i aria-hidden="true" class="pi pi-globe text-base text-roadshop-accent"></i>
             <select
               class="min-w-[8rem] appearance-none cursor-pointer bg-transparent pr-8 text-sm font-medium text-roadshop-primary focus:outline-none"
               :value="locale"

--- a/frontend/src/assets/icons/ui/clipboard.svg
+++ b/frontend/src/assets/icons/ui/clipboard.svg
@@ -1,1 +1,0 @@
-<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 18 20"><path d="M16 1h-3.278A1.992 1.992 0 0 0 11 0H7a1.993 1.993 0 0 0-1.722 1H2a2 2 0 0 0-2 2v15a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2Zm-3 14H5a1 1 0 0 1 0-2h8a1 1 0 0 1 0 2Zm0-4H5a1 1 0 0 1 0-2h8a1 1 0 1 1 0 2Zm0-5H5a1 1 0 0 1 0-2h2V2h4v2h2a1 1 0 1 1 0 2Z"/></svg>

--- a/frontend/src/assets/icons/ui/success.svg
+++ b/frontend/src/assets/icons/ui/success.svg
@@ -1,1 +1,0 @@
-<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 12"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 5.917 5.724 10.5 15 1.5"/></svg>

--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -41,9 +41,6 @@
   "footer": {
     "message": "© {year} Stitchmon Roadshop. The official online payment center for your orders."
   },
-  "language": {
-    "label": "Language"
-  },
   "loading": {
     "deepLink": "Opening the app so you can continue your payment…"
   },

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -41,9 +41,6 @@
   "footer": {
     "message": "© {year} スティッチモン ロードショップ。公式オンライン決済センターです。"
   },
-  "language": {
-    "label": "言語"
-  },
   "loading": {
     "deepLink": "お支払いアプリを開いています…"
   },

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -41,9 +41,6 @@
   "footer": {
     "message": "© {year} 스티치몬 로드샵. 공식 온라인 결제 센터입니다."
   },
-  "language": {
-    "label": "언어"
-  },
   "loading": {
     "deepLink": "결제 앱을 여는 중이에요…"
   },

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -41,9 +41,6 @@
   "footer": {
     "message": "© {year} Stitchmon 路店。官方在线支付中心。"
   },
-  "language": {
-    "label": "语言"
-  },
   "loading": {
     "deepLink": "正在打开支付应用…"
   },

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,3 +1,4 @@
+import 'primeicons/primeicons.css'
 import './assets/main.css'
 
 import { bootstrapApp } from '@/app/main'

--- a/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
+++ b/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
@@ -6,9 +6,6 @@ import { useI18nStore } from '@/localization/store'
 import type { TransferAccount } from '@/payments/services/paymentInfoService'
 import TooltipBubble from '@/shared/components/TooltipBubble.vue'
 import DialogCloseFull from '@/shared/components/DialogCloseFull.vue'
-import clipboardIcon from '@icons/ui/clipboard.svg?raw'
-import successIcon from '@icons/ui/success.svg?raw'
-
 import { useTransferCopyState, type CopyAction } from './useTransferCopyState'
 
 interface Props {
@@ -149,16 +146,15 @@ watch(
                   @blur="setHoverState(account.number, 'number', false)"
                 >
                   <span>{{ account.number }}</span>
-                  <span
-                    class="icon-wrapper flex h-3 w-3 items-center justify-center transition"
+                  <i
+                    aria-hidden="true"
+                    class="pi text-xs transition"
                     :class="
                       isCopied(account.number, 'number')
-                        ? 'text-emerald-500 group-hover:text-emerald-500'
-                        : 'text-roadshop-primary group-hover:text-roadshop-primary'
+                        ? ['pi-check-circle', 'text-emerald-500', 'group-hover:text-emerald-500']
+                        : ['pi-copy', 'text-roadshop-primary', 'group-hover:text-roadshop-primary']
                     "
-                    aria-hidden="true"
-                    v-html="isCopied(account.number, 'number') ? successIcon : clipboardIcon"
-                  ></span>
+                  ></i>
                 </button>
                 <TooltipBubble
                   :visible="isTooltipVisible(account.number, 'number')"
@@ -184,18 +180,17 @@ watch(
                 <span class="text-sm font-semibold text-white">
                   {{ isCopied(account.number, 'all') ? copiedAllButtonLabel : copyAllButtonLabel }}
                 </span>
-                <span
+                <i
                   v-if="isCopied(account.number, 'all')"
-                  class="icon-wrapper h-4 w-4 text-white"
                   aria-hidden="true"
-                  v-html="successIcon"
-                ></span>
+                  class="pi pi-check-circle text-sm text-white"
+                ></i>
               </span>
-              <span
-                class="icon-wrapper hidden h-4 w-4 items-center justify-center text-white sm:flex"
+              <i
                 aria-hidden="true"
-                v-html="isCopied(account.number, 'all') ? successIcon : clipboardIcon"
-              ></span>
+                class="pi hidden text-base text-white sm:flex"
+                :class="isCopied(account.number, 'all') ? 'pi-check-circle' : 'pi-copy'"
+              ></i>
             </button>
           </div>
         </div>
@@ -205,9 +200,7 @@ watch(
 </template>
 
 <style scoped>
-.icon-wrapper :deep(svg) {
-  width: 100%;
-  height: 100%;
-  display: block;
+.pi {
+  line-height: 1;
 }
 </style>


### PR DESCRIPTION
## Summary
- replace the transfer dialog clipboard and success indicators with PrimeIcons and remove the custom SVG assets
- update the hero language selector to use only the green PrimeIcon globe, cleaning up redundant language translations and keeping the PrimeIcons stylesheet loaded globally

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbfee09b58832c96be287d9d67b187