### PR TITLE
Simplify payment action triggers

### DIFF
--- a/frontend/src/payments/stores/paymentInteraction.store.ts
+++ b/frontend/src/payments/stores/paymentInteraction.store.ts
@@ -260,19 +260,11 @@ export const usePaymentInteractionStore = defineStore('payment-interaction', () 
   const resolveAction = createPaymentActionResolver(workflowContext)
 
   const handleMethodSelection = async (methodId: string) => {
-    const method = paymentStore.getMethodById(methodId)
-
     paymentStore.selectMethod(methodId)
 
-    if (!method) {
-      return
-    }
+    const method = selectedMethod.value
 
-    if (!selectedMethod.value) {
-      return
-    }
-
-    if (isCurrencySelectorOpen.value) {
+    if (!method || isCurrencySelectorOpen.value) {
       return
     }
 
@@ -289,7 +281,7 @@ export const usePaymentInteractionStore = defineStore('payment-interaction', () 
 
     paymentStore.chooseCurrency(currency)
 
-    if (!selectedMethod.value) {
+    if (selectedCurrency.value !== currency) {
       return
     }
 


### PR DESCRIPTION
## Summary
- rely on the payment store's selected state to decide when to run method actions
- skip currency action callbacks when the requested currency is not accepted

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc260e5234832cb395db02b62d2fcf