### PR TITLE
Remove payment descriptions from payment UI

### DIFF
--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -96,34 +96,27 @@
   },
   "payment": {
     "transfer": {
-      "name": "Bank Transfer",
-      "description": "Pay the KRW amount via bank transfer."
+      "name": "Bank Transfer"
     },
     "kakao": {
       "name": "Kakao Transfer",
-      "description": "Scan the QR code with KakaoTalk and finish checkout in seconds.",
       "cta": "Open Kakao Transfer"
     },
     "toss": {
       "name": "Toss Transfer",
-      "description": "Send your payment instantly with Toss and see the confirmation right away.",
       "cta": "Open Toss"
     },
     "naver": {
-      "name": "Naver Pay",
-      "description": "We're preparing Naver Pay so you can use your points right at checkout."
+      "name": "Naver Pay"
     },
     "alipay": {
-      "name": "Alipay",
-      "description": "We're partnering with Alipay to connect major global e-wallets, letting travelers pay with the wallet they already use."
+      "name": "Alipay"
     },
     "paypal": {
-      "name": "PayPal",
-      "description": "Soon you'll be able to check out with the PayPal account you already trust."
+      "name": "PayPal"
     },
     "card": {
-      "name": "Credit Card",
-      "description": "Visa, Mastercard, UnionPay, Amex, and JCB are on the roadmap, so you can use a familiar card checkout wherever you are."
+      "name": "Credit Card"
     }
   }
 }

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -96,34 +96,27 @@
   },
   "payment": {
     "transfer": {
-      "name": "口座振込",
-      "description": "KRWの金額は口座振込でお支払いください。"
+      "name": "口座振込"
     },
     "kakao": {
       "name": "Kakao送金",
-      "description": "QRコードをKakaoTalkで読み取り、数秒で決済を完了できます。",
       "cta": "Kakao送金を開く"
     },
     "toss": {
       "name": "Toss送金",
-      "description": "Toss送金ですぐにお支払いを済ませ、その場で確認できます。",
       "cta": "Toss送金を開く"
     },
     "naver": {
-      "name": "Naver Pay",
-      "description": "Naver Payでもその場でポイント決済できるよう準備中です。"
+      "name": "Naver Pay"
     },
     "alipay": {
-      "name": "Alipay（アリペイ）",
-      "description": "Alipayを通じて主要な海外電子ウォレットを連携し、いつものウォレットで支払えるようにします。"
+      "name": "Alipay（アリペイ）"
     },
     "paypal": {
-      "name": "PayPal（ペイパル）",
-      "description": "普段使いのPayPalアカウントで決済できるよう近日対応予定です。"
+      "name": "PayPal（ペイパル）"
     },
     "card": {
-      "name": "クレジットカード",
-      "description": "Visa・Mastercard・UnionPay・Amex・JCBなどの世界的なカード決済に近日対応します。"
+      "name": "クレジットカード"
     }
   }
 }

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -96,34 +96,27 @@
   },
   "payment": {
     "transfer": {
-      "name": "계좌이체",
-      "description": "원화 금액은 계좌이체로 보내 결제를 마무리해 주세요."
+      "name": "계좌이체"
     },
     "kakao": {
       "name": "카카오송금",
-      "description": "카카오톡으로 QR을 스캔해 빠르게 결제하세요.",
       "cta": "카카오송금 열기"
     },
     "toss": {
       "name": "토스송금",
-      "description": "토스송금으로 바로 결제하고 즉시 확인하세요.",
       "cta": "토스송금 열기"
     },
     "naver": {
-      "name": "네이버페이",
-      "description": "현장에서도 네이버페이 포인트로 간편하게 결제하실 수 있도록 준비 중이에요."
+      "name": "네이버페이"
     },
     "alipay": {
-      "name": "알리페이",
-      "description": "알리페이와 연동해 주요 글로벌 전자지갑을 연결하고, 여행 중에도 익숙한 지갑으로 결제하실 수 있도록 준비하고 있어요."
+      "name": "알리페이"
     },
     "paypal": {
-      "name": "페이팔",
-      "description": "글로벌 고객이 익숙한 PayPal 계정으로 손쉽게 결제하실 수 있도록 준비하고 있어요."
+      "name": "페이팔"
     },
     "card": {
-      "name": "신용카드",
-      "description": "Visa, Mastercard, UnionPay, Amex, JCB 등 주요 카드 결제를 곧 지원할 예정이에요."
+      "name": "신용카드"
     }
   }
 }

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -96,34 +96,27 @@
   },
   "payment": {
     "transfer": {
-      "name": "银行转账",
-      "description": "请通过银行转账支付韩元金额。"
+      "name": "银行转账"
     },
     "kakao": {
       "name": "Kakao 汇款",
-      "description": "使用 KakaoTalk 扫描二维码，几秒内完成结账。",
       "cta": "打开 Kakao 汇款"
     },
     "toss": {
       "name": "Toss 转账",
-      "description": "通过 Toss 转账即时付款并立即确认。",
       "cta": "打开 Toss"
     },
     "naver": {
-      "name": "Naver Pay",
-      "description": "我们正在筹备 Naver Pay，让你当场就能使用积分付款。"
+      "name": "Naver Pay"
     },
     "alipay": {
-      "name": "支付宝",
-      "description": "我们计划通过 Alipay 接入主要的全球电子钱包，让旅客可以继续使用熟悉的钱包付款。"
+      "name": "支付宝"
     },
     "paypal": {
-      "name": "PayPal",
-      "description": "你很快就能用熟悉的 PayPal 账户轻松结账。"
+      "name": "PayPal"
     },
     "card": {
-      "name": "信用卡",
-      "description": "我们即将上线 Visa、Mastercard、UnionPay、Amex、JCB 等全球银行卡支付，让你随时享受熟悉的结账体验。"
+      "name": "信用卡"
     }
   }
 }

--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -36,7 +36,6 @@ const localizedSections = computed(() =>
   sections.value.map((section) => ({
     section,
     title: i18nStore.t(`sections.${section.category.toLowerCase()}.title`),
-    description: i18nStore.t(`sections.${section.category.toLowerCase()}.description`),
   })),
 )
 
@@ -86,7 +85,6 @@ const onLaunchTossInstructionDialog = () => {
       :key="`${entry.section.category}-${index}`"
       :section="entry.section"
       :title="entry.title"
-      :description="entry.description"
       @select="onSelectMethod"
     />
 

--- a/frontend/src/payments/components/OptionCard.vue
+++ b/frontend/src/payments/components/OptionCard.vue
@@ -6,7 +6,6 @@ import type { PaymentCategory } from '@/payments/types'
 
 interface Props {
   name: string
-  description: string
   supportedCurrencies: string[]
   icons?: Array<{
     src: string
@@ -102,10 +101,6 @@ onBeforeUnmount(() => {
         {{ currency }}
       </span>
     </div>
-
-    <p class="flex-1 text-sm leading-relaxed text-slate-600">
-      {{ props.description }}
-    </p>
 
     <p
       v-if="props.isSelected && props.supportedCurrencies.length > 1"

--- a/frontend/src/payments/components/Section.vue
+++ b/frontend/src/payments/components/Section.vue
@@ -5,7 +5,6 @@ import type { LocalizedPaymentSection } from '@/payments/composables/useLocalize
 interface Props {
   section: LocalizedPaymentSection
   title: string
-  description: string
 }
 
 const props = defineProps<Props>()
@@ -19,14 +18,12 @@ const emit = defineEmits<{
   <section class="flex flex-col gap-6">
     <div class="flex flex-col gap-2">
       <h2 class="text-2xl font-semibold text-roadshop-primary">{{ title }}</h2>
-      <p class="text-sm text-slate-500">{{ description }}</p>
     </div>
     <div class="grid gap-6 md:grid-cols-2">
       <OptionCard
         v-for="method in section.methods"
         :key="method.id"
         :name="method.name"
-        :description="method.description"
         :supported-currencies="method.supportedCurrencies"
         :icons="method.icons"
         :is-selected="method.isSelected"

--- a/frontend/src/payments/composables/useLocalizedSections.ts
+++ b/frontend/src/payments/composables/useLocalizedSections.ts
@@ -8,7 +8,6 @@ import { usePaymentStore } from '@/payments/stores/payment.store'
 
 export type LocalizedPaymentMethod = PaymentMethod & {
   name: string
-  description: string
   supportedCurrencies: string[]
   isSelected: boolean
 }
@@ -47,7 +46,6 @@ export const useLocalizedSections = () => {
           .map((method) => ({
             ...method,
             name: i18nStore.t(`payment.${method.id}.name`),
-            description: i18nStore.t(`payment.${method.id}.description`),
             isSelected: method.id === selectedMethodId.value,
           }))
           .filter((method) => method.name),


### PR DESCRIPTION
## Summary
- remove payment description copy from payment method localization files
- update payment section components to stop rendering descriptions
- simplify localized payment data to only include names and selection state

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68dc2c80b7d0832c88c4a2b3a43a0aa0