### PR TITLE
Update currency selector descriptions across locales

### DIFF
--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -68,7 +68,7 @@
   },
   "currencySelector": {
     "title": "Choose a currency",
-    "description": "Select the currency you want to use with {method}."
+    "description": "Choose the currency to use for {method} payments."
   },
   "dialog": {
     "close": "Close"

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -68,7 +68,7 @@
   },
   "currencySelector": {
     "title": "通貨を選択してください",
-    "description": "{method}で利用する通貨をお選びください。"
+    "description": "{method} 決済に使用する通貨を選択してください。"
   },
   "dialog": {
     "close": "閉じる"

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -68,7 +68,7 @@
   },
   "currencySelector": {
     "title": "통화를 선택하세요",
-    "description": "{method}로 사용할 통화를 선택해 주세요."
+    "description": "{method} 결제에 사용할 통화를 선택하세요."
   },
   "dialog": {
     "close": "닫기"

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -68,7 +68,7 @@
   },
   "currencySelector": {
     "title": "选择货币",
-    "description": "请选择使用 {method} 时的付款货币。"
+    "description": "请选择用于 {method} 付款的货币。"
   },
   "dialog": {
     "close": "关闭"


### PR DESCRIPTION
## Summary
- align the currency selector description across English, Korean, Japanese, and Chinese translations with the new wording

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc33204e7c832caeea32a99fb578cb