### PR TITLE
Refactor deep link launch handling and update QR dialog

### DIFF
--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -127,11 +127,7 @@ const onLaunchTossInstructionDialog = () => {
         v-if="popupQrValue"
         class="mt-6 flex flex-col items-center gap-3"
       >
-        <QrCodeDisplay
-          class="shadow-lg"
-          :value="popupQrValue"
-          :icon="popupQrIcon ?? undefined"
-        />
+        <QrCodeDisplay :value="popupQrValue" :icon="popupQrIcon ?? undefined"/>
         <p v-if="popupQrHint" class="text-center text-xs text-slate-500">
           {{ popupQrHint }}
         </p>

--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -127,7 +127,11 @@ const onLaunchTossInstructionDialog = () => {
         v-if="popupQrValue"
         class="mt-6 flex flex-col items-center gap-3"
       >
-        <QrCodeDisplay :value="popupQrValue" :icon="popupQrIcon ?? undefined" />
+        <QrCodeDisplay
+          class="shadow-lg"
+          :value="popupQrValue"
+          :icon="popupQrIcon ?? undefined"
+        />
         <p v-if="popupQrHint" class="text-center text-xs text-slate-500">
           {{ popupQrHint }}
         </p>

--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -127,7 +127,7 @@ const onLaunchTossInstructionDialog = () => {
         v-if="popupQrValue"
         class="mt-6 flex flex-col items-center gap-3"
       >
-        <QrCodeDisplay :value="popupQrValue" :icon="popupQrIcon ?? undefined"/>
+        <QrCodeDisplay :value="popupQrValue" :icon="popupQrIcon ?? undefined" />
         <p v-if="popupQrHint" class="text-center text-xs text-slate-500">
           {{ popupQrHint }}
         </p>

--- a/frontend/src/payments/workflows/types.ts
+++ b/frontend/src/payments/workflows/types.ts
@@ -17,7 +17,6 @@ export type PaymentActionContext = {
   ) => void
   setDeepLinkChecking: (value: boolean) => void
   waitForDeepLinkResult: (timeoutMs?: number) => Promise<boolean>
-  navigateToDeepLink: (url: string) => boolean
   isMobileDevice: () => boolean
   openUrlInNewTab: (url: string | null) => void
   copyTossAccountInfo: () => Promise<boolean>


### PR DESCRIPTION
## Summary
- extend the reusable launchDeepLink helper to handle mobile detection, standardized navigation, and launch monitoring across providers
- update Kakao and Toss deep link workflows (including Toss reopen) to rely on the centralized launcher without opening new tabs while surfacing the appropriate popups
- apply a stronger shadow to the QR code in the desktop deep-link dialog for better emphasis

## Testing
- npm run lint *(fails: existing Vue multi-word component rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_68dd21114714832cb660f043e6d1eede