### PR TITLE
Simplify deep link launch options

### DIFF
--- a/frontend/src/payments/services/deepLinkService.ts
+++ b/frontend/src/payments/services/deepLinkService.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue'
 
 import type { DeepLinkProvider } from '@/payments/types'
 import type { KakaoPaymentInfo, TossPaymentInfo } from '@/payments/services/paymentInfoService'
+import { isMobileDevice } from '@/shared/utils/device'
 
 export const createTossDeepLink = (info: TossPaymentInfo): string => {
   const params = new URLSearchParams({
@@ -57,25 +58,19 @@ export const isDeepLinkChecking = ref(false)
 
 interface LaunchDeepLinkOptions {
   timeoutMs: number
-  waitForDeepLinkResult: (timeoutMs: number) => Promise<boolean>
   onNotInstalled?: () => void
   onNotMobile?: () => void
-  isMobileDevice: () => boolean
 }
 
 export const launchDeepLink = async (
   url: string,
   {
     timeoutMs,
-    waitForDeepLinkResult,
     onNotInstalled,
     onNotMobile,
-    isMobileDevice,
   }: LaunchDeepLinkOptions,
 ) => {
-  const isMobile = isMobileDevice()
-
-  if (!isMobile) {
+  if (!isMobileDevice()) {
     onNotMobile?.()
   }
 

--- a/frontend/src/payments/stores/paymentInteraction.store.ts
+++ b/frontend/src/payments/stores/paymentInteraction.store.ts
@@ -2,11 +2,7 @@ import { computed, ref } from 'vue'
 import { defineStore, storeToRefs } from 'pinia'
 
 import { useI18nStore } from '@/localization/store'
-import {
-  isDeepLinkChecking as deepLinkChecking,
-  launchDeepLink,
-  waitForDeepLinkLaunch,
-} from '@/payments/services/deepLinkService'
+import { isDeepLinkChecking as deepLinkChecking, launchDeepLink } from '@/payments/services/deepLinkService'
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 import { usePaymentStore } from '@/payments/stores/payment.store'
 import { createCountdownManager } from '@/payments/stores/utils/createCountdownManager'
@@ -17,7 +13,6 @@ import type {
   DeepLinkPopupType,
   PaymentActionContext,
 } from '@/payments/workflows/types'
-import { isMobileDevice } from '@/shared/utils/device'
 import { openUrlInNewTab } from '@/shared/utils/navigation'
 import { copyText } from '@/shared/utils/clipboard'
 
@@ -43,8 +38,6 @@ const buildWorkflowContext = (
   ensurePaymentInfoLoaded: paymentInfoStore.ensureLoaded,
   getDeepLinkInfo: paymentInfoStore.getDeepLinkInfo,
   showDeepLinkPopup: showPopup,
-  waitForDeepLinkResult: waitForDeepLinkLaunch,
-  isMobileDevice,
   openUrlInNewTab,
   copyTossAccountInfo,
   showTossInstructionDialog,
@@ -168,10 +161,8 @@ export const usePaymentInteractionStore = defineStore('payment-interaction', () 
     const deepLink = tossDeepLinkUrl.value
     await launchDeepLink(deepLink, {
       timeoutMs: 2000,
-      waitForDeepLinkResult: waitForDeepLinkLaunch,
       onNotInstalled: () => showPopup('not-installed', 'toss'),
       onNotMobile: () => showPopup('not-mobile', 'toss', { deepLinkUrl: deepLink }),
-      isMobileDevice,
     })
   }
 

--- a/frontend/src/payments/workflows/actions/kakao.ts
+++ b/frontend/src/payments/workflows/actions/kakao.ts
@@ -32,10 +32,8 @@ const runKakaoWorkflow = async (context: PaymentActionContext) => {
 
   await launchDeepLink(deepLink, {
     timeoutMs: 1500,
-    waitForDeepLinkResult: context.waitForDeepLinkResult,
     onNotInstalled: () => context.showDeepLinkPopup('not-installed', 'kakao'),
     onNotMobile: () => context.showDeepLinkPopup('not-mobile', 'kakao', { deepLinkUrl: deepLink }),
-    isMobileDevice: context.isMobileDevice,
   })
 }
 

--- a/frontend/src/payments/workflows/actions/toss.ts
+++ b/frontend/src/payments/workflows/actions/toss.ts
@@ -45,10 +45,8 @@ const runTossWorkflow = async (context: PaymentActionContext) => {
   try {
     await launchDeepLink(deepLink, {
       timeoutMs: 2000,
-      waitForDeepLinkResult: context.waitForDeepLinkResult,
       onNotInstalled: () => context.showDeepLinkPopup('not-installed', 'toss'),
       onNotMobile: () => context.showDeepLinkPopup('not-mobile', 'toss', { deepLinkUrl: deepLink }),
-      isMobileDevice: context.isMobileDevice,
     })
   } finally {
     context.completeTossInstructionDialog()

--- a/frontend/src/payments/workflows/types.ts
+++ b/frontend/src/payments/workflows/types.ts
@@ -15,8 +15,6 @@ export type PaymentActionContext = {
     provider: DeepLinkProvider,
     options?: DeepLinkPopupOptions,
   ) => void
-  waitForDeepLinkResult: (timeoutMs?: number) => Promise<boolean>
-  isMobileDevice: () => boolean
   openUrlInNewTab: (url: string | null) => void
   copyTossAccountInfo: () => Promise<boolean>
   showTossInstructionDialog: (seconds: number) => Promise<boolean>


### PR DESCRIPTION
## Summary
- import the shared isMobileDevice helper directly within the deep link service
- drop the unused waitForDeepLinkResult plumbing from payment workflows and store
- adjust deep link launch calls to rely on the centralized mobile detection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd2efd5930832cac203d55edd5b41b