### PR TITLE
Refine payment localization structure

### DIFF
--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -3,6 +3,49 @@
     "krw": "KRW payments",
     "global": "Global payments"
   },
+  "options": {
+    "transfer": "Bank Transfer",
+    "kakao": "Kakao Transfer",
+    "toss": "Toss Transfer",
+    "alipay": "Alipay",
+    "card": "Credit Card"
+  },
+  "dialogs": {
+    "close": "Close",
+    "confirm": "OK",
+    "notMobile": {
+      "title": "Open on your mobile device",
+      "description": "The {provider} transfer link only opens in the mobile app. Please continue on your phone."
+    },
+    "notInstalled": {
+      "title": "Having trouble opening the app?",
+      "description": "If the {provider} app didn't open, please make sure it's installed and try again.",
+      "qrHint": "Scan to open the {provider} app"
+    },
+    "transferAccounts": {
+      "title": "Bank transfer details",
+      "description": "Send {amountWithCurrency} to one of the accounts below.",
+      "amountWithCurrency": "{amount} KRW",
+      "copy": {
+        "all": "Copy transfer details",
+        "accountNo": "Copy only account number"
+      },
+      "copied": {
+        "all": "Copied to clipboard",
+        "accountNo": "Account number copied"
+      }
+    },
+    "currencySelector": {
+      "title": "Choose a currency",
+      "description": "Choose the currency to use for {method} payments."
+    },
+    "tossInstruction": {
+      "title": "Send with Toss",
+      "description": "We've <strong>automatically copied</strong> the account details you need for Toss.",
+      "launchCta": "Go to Toss",
+      "reopen": "Reopen Toss"
+    }
+  },
   "status": {
     "empty": "No payment methods are available right now.",
     "loading": {
@@ -11,59 +54,6 @@
     },
     "errors": {
       "loadMethods": "We couldn't load the payment methods. Please try again."
-    }
-  },
-  "dialogs": {
-    "close": "Close",
-    "confirm": "OK",
-    "deepLink": {
-      "titles": {
-        "notMobile": "Open on your mobile device",
-        "notInstalled": "Having trouble opening the app?"
-      },
-      "description": {
-        "notMobile": "The {provider} transfer link only opens in the mobile app. Please continue on your phone.",
-        "notInstalled": "If {provider} didn't open, please make sure it's installed and try again.",
-        "qrHint": "Scan to open the {provider} app"
-      }
-    },
-    "transferAccounts": {
-      "title": "Bank transfer details",
-      "description": "Send {amountWithCurrency} to one of the accounts below.",
-      "copyAll": "Copy all details",
-      "copyNumber": "Copy only account number",
-      "copyAllButton": "Copy transfer details",
-      "copiedAllButton": "Copied to clipboard",
-      "copiedNumber": "Account number copied"
-    }
-  },
-  "currencySelector": {
-    "title": "Choose a currency",
-    "description": "Choose the currency to use for {method} payments."
-  },
-  "tossInstruction": {
-    "title": "Send with Toss",
-    "description": "We've <strong>automatically copied</strong> the account details you need for Toss.",
-    "launchCta": "Go to Toss",
-    "reopen": "Reopen Toss"
-  },
-  "payment": {
-    "transfer": {
-      "name": "Bank Transfer"
-    },
-    "kakao": {
-      "name": "Kakao Transfer",
-      "cta": "Open Kakao Transfer"
-    },
-    "toss": {
-      "name": "Toss Transfer",
-      "cta": "Open Toss"
-    },
-    "alipay": {
-      "name": "Alipay"
-    },
-    "card": {
-      "name": "Credit Card"
     }
   }
 }

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -3,6 +3,49 @@
     "krw": "KRW 決済",
     "global": "グローバル決済"
   },
+  "options": {
+    "transfer": "口座振込",
+    "kakao": "Kakao送金",
+    "toss": "Toss送金",
+    "alipay": "Alipay（アリペイ）",
+    "card": "クレジットカード"
+  },
+  "dialogs": {
+    "close": "閉じる",
+    "confirm": "OK",
+    "notMobile": {
+      "title": "モバイル専用です",
+      "description": "{provider}送金リンクはモバイルアプリでのみ開けます。スマートフォンで再度お試しください。"
+    },
+    "notInstalled": {
+      "title": "アプリが起動しませんか？",
+      "description": "{provider}アプリに移動しなかった場合は、インストール状況を確認してからもう一度お試しください。",
+      "qrHint": "QRコードをスキャンして{provider}アプリに移動します"
+    },
+    "transferAccounts": {
+      "title": "口座振込のご案内",
+      "description": "下記のいずれかの口座へ {amountWithCurrency} をお振り込みください。",
+      "amountWithCurrency": "{amount} KRW",
+      "copy": {
+        "all": "振込情報をコピー",
+        "accountNo": "口座番号のみコピー"
+      },
+      "copied": {
+        "all": "クリップボードにコピーしました",
+        "accountNo": "口座番号のみコピーしました"
+      }
+    },
+    "currencySelector": {
+      "title": "通貨を選択してください",
+      "description": "{method} 決済に使用する通貨を選択してください。"
+    },
+    "tossInstruction": {
+      "title": "Tossで送金",
+      "description": "送金に必要な口座情報を<strong>自動でコピー</strong>しました。",
+      "launchCta": "Tossへ移動",
+      "reopen": "Tossをもう一度開く"
+    }
+  },
   "status": {
     "empty": "現在利用できる決済方法はありません。",
     "loading": {
@@ -11,59 +54,6 @@
     },
     "errors": {
       "loadMethods": "決済方法を読み込めませんでした。再度お試しください。"
-    }
-  },
-  "dialogs": {
-    "close": "閉じる",
-    "confirm": "OK",
-    "deepLink": {
-      "titles": {
-        "notMobile": "モバイル専用です",
-        "notInstalled": "アプリが起動しませんか？"
-      },
-      "description": {
-        "notMobile": "{provider}送金リンクはモバイルアプリでのみ開けます。スマートフォンで再度お試しください。",
-        "notInstalled": "{provider}に移動しなかった場合は、インストール状況を確認してからもう一度お試しください。",
-        "qrHint": "QRコードをスキャンして{provider}アプリに移動します"
-      }
-    },
-    "transferAccounts": {
-      "title": "口座振込のご案内",
-      "description": "下記のいずれかの口座へ {amountWithCurrency} をお振り込みください。",
-      "copyAll": "すべての情報をコピー",
-      "copyNumber": "口座番号のみコピー",
-      "copyAllButton": "振込情報をコピー",
-      "copiedAllButton": "クリップボードにコピーしました",
-      "copiedNumber": "口座番号のみコピーしました"
-    }
-  },
-  "currencySelector": {
-    "title": "通貨を選択してください",
-    "description": "{method} 決済に使用する通貨を選択してください。"
-  },
-  "tossInstruction": {
-    "title": "Tossで送金",
-    "description": "送金に必要な口座情報を<strong>自動でコピー</strong>しました。",
-    "launchCta": "Tossへ移動",
-    "reopen": "Tossをもう一度開く"
-  },
-  "payment": {
-    "transfer": {
-      "name": "口座振込"
-    },
-    "kakao": {
-      "name": "Kakao送金",
-      "cta": "Kakao送金を開く"
-    },
-    "toss": {
-      "name": "Toss送金",
-      "cta": "Toss送金を開く"
-    },
-    "alipay": {
-      "name": "Alipay（アリペイ）"
-    },
-    "card": {
-      "name": "クレジットカード"
     }
   }
 }

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -3,6 +3,49 @@
     "krw": "KRW 결제",
     "global": "글로벌 결제"
   },
+  "options": {
+    "transfer": "계좌이체",
+    "kakao": "카카오송금",
+    "toss": "토스송금",
+    "alipay": "알리페이",
+    "card": "신용카드"
+  },
+  "dialogs": {
+    "close": "닫기",
+    "confirm": "확인",
+    "notMobile": {
+      "title": "모바일에서만 이용할 수 있어요",
+      "description": "{provider} 송금링크는 모바일에서만 열려요. 휴대폰에서 다시 시도해 주세요."
+    },
+    "notInstalled": {
+      "title": "앱이 실행되지 않았나요?",
+      "description": "{provider} 앱으로 이동하지 않았다면 설치 여부를 확인한 후 다시 시도해 주세요.",
+      "qrHint": "스캔해서 {provider} 앱으로 이동합니다"
+    },
+    "transferAccounts": {
+      "title": "계좌이체 정보",
+      "description": "{amountWithCurrency} 금액을 아래 계좌 중 하나로 보내 주세요.",
+      "amountWithCurrency": "{amount}원",
+      "copy": {
+        "all": "이체 정보 복사",
+        "accountNo": "계좌번호만 복사"
+      },
+      "copied": {
+        "all": "클립보드에 복사됨",
+        "accountNo": "계좌번호만 복사했어요"
+      }
+    },
+    "currencySelector": {
+      "title": "통화를 선택하세요",
+      "description": "{method} 결제에 사용할 통화를 선택하세요."
+    },
+    "tossInstruction": {
+      "title": "토스로 송금하기",
+      "description": "송금에 필요한 계좌 정보를 <strong>자동으로 복사</strong>해 두었어요.",
+      "launchCta": "토스로 이동하기",
+      "reopen": "토스 다시열기"
+    }
+  },
   "status": {
     "empty": "현재 사용 가능한 결제 수단이 없습니다.",
     "loading": {
@@ -11,59 +54,6 @@
     },
     "errors": {
       "loadMethods": "결제 수단을 불러오지 못했어요. 다시 시도해 주세요."
-    }
-  },
-  "dialogs": {
-    "close": "닫기",
-    "confirm": "확인",
-    "deepLink": {
-      "titles": {
-        "notMobile": "모바일에서만 이용할 수 있어요",
-        "notInstalled": "앱이 실행되지 않았나요?"
-      },
-      "description": {
-        "notMobile": "{provider} 송금링크는 모바일에서만 열려요. 휴대폰에서 다시 시도해 주세요.",
-        "notInstalled": "{provider} 송금링크로 이동하지 않았다면 설치 여부를 확인한 후 다시 시도해 주세요.",
-        "qrHint": "스캔해서 {provider} 앱으로 이동합니다"
-      }
-    },
-    "transferAccounts": {
-      "title": "계좌이체 정보",
-      "description": "{amountWithCurrency} 금액을 아래 계좌 중 하나로 보내 주세요.",
-      "copyAll": "전체 정보 복사",
-      "copyNumber": "계좌번호만 복사",
-      "copyAllButton": "이체 정보 복사",
-      "copiedAllButton": "클립보드에 복사됨",
-      "copiedNumber": "계좌번호만 복사했어요"
-    }
-  },
-  "currencySelector": {
-    "title": "통화를 선택하세요",
-    "description": "{method} 결제에 사용할 통화를 선택하세요."
-  },
-  "tossInstruction": {
-    "title": "토스로 송금하기",
-    "description": "송금에 필요한 계좌 정보를 <strong>자동으로 복사</strong>해 두었어요.",
-    "launchCta": "토스로 이동하기",
-    "reopen": "토스 다시열기"
-  },
-  "payment": {
-    "transfer": {
-      "name": "계좌이체"
-    },
-    "kakao": {
-      "name": "카카오송금",
-      "cta": "카카오송금 열기"
-    },
-    "toss": {
-      "name": "토스송금",
-      "cta": "토스송금 열기"
-    },
-    "alipay": {
-      "name": "알리페이"
-    },
-    "card": {
-      "name": "신용카드"
     }
   }
 }

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -3,6 +3,49 @@
     "krw": "韩元支付",
     "global": "全球支付"
   },
+  "options": {
+    "transfer": "银行转账",
+    "kakao": "Kakao 汇款",
+    "toss": "Toss 转账",
+    "alipay": "支付宝",
+    "card": "信用卡"
+  },
+  "dialogs": {
+    "close": "关闭",
+    "confirm": "好的",
+    "notMobile": {
+      "title": "仅限移动设备使用",
+      "description": "{provider} 链接只能在移动设备上打开。请在手机上重试。"
+    },
+    "notInstalled": {
+      "title": "应用没有打开吗？",
+      "description": "如果没有跳转到 {provider} 应用，请确认已安装后再试一次。",
+      "qrHint": "扫描二维码前往 {provider} 应用"
+    },
+    "transferAccounts": {
+      "title": "银行转账信息",
+      "description": "请将 {amountWithCurrency} 转入下方任一账户。",
+      "amountWithCurrency": "{amount} 韩元",
+      "copy": {
+        "all": "复制转账信息",
+        "accountNo": "仅复制账号"
+      },
+      "copied": {
+        "all": "已复制到剪贴板",
+        "accountNo": "仅复制了账号"
+      }
+    },
+    "currencySelector": {
+      "title": "选择货币",
+      "description": "请选择用于 {method} 付款的货币。"
+    },
+    "tossInstruction": {
+      "title": "使用 Toss 转账",
+      "description": "已将转账所需的账户信息<strong>自动复制</strong>好了。",
+      "launchCta": "前往 Toss",
+      "reopen": "重新打开 Toss"
+    }
+  },
   "status": {
     "empty": "目前没有可用的支付方式。",
     "loading": {
@@ -11,59 +54,6 @@
     },
     "errors": {
       "loadMethods": "无法加载支付方式，请稍后再试。"
-    }
-  },
-  "dialogs": {
-    "close": "关闭",
-    "confirm": "好的",
-    "deepLink": {
-      "titles": {
-        "notMobile": "仅限移动设备使用",
-        "notInstalled": "应用没有打开吗？"
-      },
-      "description": {
-        "notMobile": "{provider} 链接只能在移动设备上打开。请在手机上重试。",
-        "notInstalled": "如果没有跳转到 {provider}，请确认已安装后再试一次。",
-        "qrHint": "扫描二维码前往 {provider} 应用"
-      }
-    },
-    "transferAccounts": {
-      "title": "银行转账信息",
-      "description": "请将 {amountWithCurrency} 转入下方任一账户。",
-      "copyAll": "复制全部信息",
-      "copyNumber": "仅复制账号",
-      "copyAllButton": "复制转账信息",
-      "copiedAllButton": "已复制到剪贴板",
-      "copiedNumber": "仅复制了账号"
-    }
-  },
-  "currencySelector": {
-    "title": "选择货币",
-    "description": "请选择用于 {method} 付款的货币。"
-  },
-  "tossInstruction": {
-    "title": "使用 Toss 转账",
-    "description": "已将转账所需的账户信息<strong>自动复制</strong>好了。",
-    "launchCta": "前往 Toss",
-    "reopen": "重新打开 Toss"
-  },
-  "payment": {
-    "transfer": {
-      "name": "银行转账"
-    },
-    "kakao": {
-      "name": "Kakao 汇款",
-      "cta": "打开 Kakao 汇款"
-    },
-    "toss": {
-      "name": "Toss 转账",
-      "cta": "打开 Toss"
-    },
-    "alipay": {
-      "name": "支付宝"
-    },
-    "card": {
-      "name": "信用卡"
     }
   }
 }

--- a/frontend/src/payments/components/CurrencySelectorDialog.vue
+++ b/frontend/src/payments/components/CurrencySelectorDialog.vue
@@ -19,9 +19,9 @@ const emit = defineEmits<{
 
 const i18nStore = useI18nStore()
 
-const title = computed(() => i18nStore.t('currencySelector.title'))
+const title = computed(() => i18nStore.t('dialogs.currencySelector.title'))
 const description = computed(() =>
-  i18nStore.t('currencySelector.description').replace('{method}', props.methodName),
+  i18nStore.t('dialogs.currencySelector.description').replace('{method}', props.methodName),
 )
 
 const onSelectCurrency = (currency: string) => {

--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -60,7 +60,7 @@ const hasVisibleMethods = computed(() =>
 )
 
 const selectedMethodName = computed(() =>
-  selectedMethod.value ? i18nStore.t(`payment.${selectedMethod.value.id}.name`) : '',
+  selectedMethod.value ? i18nStore.t(`options.${selectedMethod.value.id}`) : '',
 )
 
 const selectedMethodCurrencies = computed(() => selectedMethod.value?.supportedCurrencies ?? [])
@@ -68,23 +68,33 @@ const selectedMethodCurrencies = computed(() => selectedMethod.value?.supportedC
 const isNotMobileDialog = computed(() => dialogContent.value?.type === 'not-mobile')
 const dialogQrValue = computed(() => dialogContent.value?.deepLinkUrl ?? null)
 const dialogQrHint = computed(() => {
-  if (!dialogContent.value) {
+  if (!dialogContent.value?.deepLinkUrl) {
     return null
   }
 
-  const templateKey = 'dialogs.deepLink.description.qrHint'
-  const template = i18nStore.t(templateKey)
+  const typeKey =
+    dialogContent.value.type === 'not-mobile'
+      ? 'dialogs.notMobile.qrHint'
+      : 'dialogs.notInstalled.qrHint'
 
-  if (template === templateKey) {
-    return null
+  const candidateKeys = [typeKey, 'dialogs.notInstalled.qrHint']
+
+  for (const key of candidateKeys) {
+    const template = i18nStore.t(key)
+
+    if (template === key) {
+      continue
+    }
+
+    const providerLabel = i18nStore.t(
+      `options.${dialogContent.value.provider}`,
+      dialogContent.value.provider,
+    )
+
+    return template.split('{provider}').join(providerLabel)
   }
 
-  const providerLabel = i18nStore.t(
-    `payment.${dialogContent.value.provider}.name`,
-    dialogContent.value.provider,
-  )
-
-  return template.split('{provider}').join(providerLabel)
+  return null
 })
 const deepLinkProviderIcons = computed(() =>
   methods.value.reduce<Partial<Record<DeepLinkProvider, PaymentIcon>>>((map, method) => {

--- a/frontend/src/payments/components/TossInstructionDialog.vue
+++ b/frontend/src/payments/components/TossInstructionDialog.vue
@@ -22,11 +22,11 @@ const emit = defineEmits<{
 
 const i18nStore = useI18nStore()
 
-const title = computed(() => i18nStore.t('tossInstruction.title'))
-const description = computed(() => i18nStore.t('tossInstruction.description'))
+const title = computed(() => i18nStore.t('dialogs.tossInstruction.title'))
+const description = computed(() => i18nStore.t('dialogs.tossInstruction.description'))
 const closeLabel = computed(() => i18nStore.t('dialogs.close'))
-const launchLabel = computed(() => i18nStore.t('tossInstruction.launchCta'))
-const reopenLabel = computed(() => i18nStore.t('tossInstruction.reopen'))
+const launchLabel = computed(() => i18nStore.t('dialogs.tossInstruction.launchCta'))
+const reopenLabel = computed(() => i18nStore.t('dialogs.tossInstruction.reopen'))
 const isCountingDown = computed(() => props.countdown > 0)
 
 const onClose = () => {

--- a/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
+++ b/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
@@ -37,20 +37,13 @@ const localeNumberFormats: Record<string, string> = {
 const numberFormatter = computed(() => new Intl.NumberFormat(localeNumberFormats[locale.value] ?? 'en-US'))
 const formattedAmount = computed(() => numberFormatter.value.format(props.amount))
 
-const formattedAmountWithCurrency = computed(() => {
-  switch (locale.value) {
-    case 'ko':
-      return `${formattedAmount.value}원`
-    case 'zh':
-      return `${formattedAmount.value} 韩元`
-    case 'ja':
-      return `${formattedAmount.value} KRW`
-    default:
-      return `${formattedAmount.value} KRW`
-  }
-})
-
 const formattedAmountForCopy = computed(() => new Intl.NumberFormat('ko-KR').format(props.amount))
+
+const formatAmountWithCurrency = (value: string) =>
+  i18nStore.t('dialogs.transferAccounts.amountWithCurrency').replace('{amount}', value)
+
+const amountWithCurrency = computed(() => formatAmountWithCurrency(formattedAmount.value))
+const amountWithCurrencyForCopy = computed(() => formatAmountWithCurrency(formattedAmountForCopy.value))
 
 const title = computed(() => i18nStore.t('dialogs.transferAccounts.title'))
 const descriptionHtml = computed(() =>
@@ -58,19 +51,18 @@ const descriptionHtml = computed(() =>
     .t('dialogs.transferAccounts.description')
     .replace(
       '{amountWithCurrency}',
-      `<strong class="font-semibold text-roadshop-primary">${formattedAmountWithCurrency.value}</strong>`,
+      `<strong class="font-semibold text-roadshop-primary">${amountWithCurrency.value}</strong>`,
     ),
 )
-const copyAllLabel = computed(() => i18nStore.t('dialogs.transferAccounts.copyAll'))
-const copyNumberLabel = computed(() => i18nStore.t('dialogs.transferAccounts.copyNumber'))
-const copiedNumberLabel = computed(() => i18nStore.t('dialogs.transferAccounts.copiedNumber'))
-const copyAllButtonLabel = computed(() => i18nStore.t('dialogs.transferAccounts.copyAllButton'))
-const copiedAllButtonLabel = computed(() => i18nStore.t('dialogs.transferAccounts.copiedAllButton'))
+const copyAllLabel = computed(() => i18nStore.t('dialogs.transferAccounts.copy.all'))
+const copyNumberLabel = computed(() => i18nStore.t('dialogs.transferAccounts.copy.accountNo'))
+const copiedAllLabel = computed(() => i18nStore.t('dialogs.transferAccounts.copied.all'))
+const copiedNumberLabel = computed(() => i18nStore.t('dialogs.transferAccounts.copied.accountNo'))
 
 const getIconForBank = (bank: string) => getFirmIcon(bank)
 
 const copyTransferDetails = async (account: TransferAccount) => {
-  const amountText = `${formattedAmountForCopy.value}원`
+  const amountText = amountWithCurrencyForCopy.value
   const payload = `${account.bank} ${account.number} ${account.holder} [${amountText}]`
   await handleCopyAll(account.number, payload)
 }
@@ -166,7 +158,7 @@ watch(
             >
               <span class="flex items-center gap-2 sm:hidden">
                 <span class="font-semibold text-white">
-                  {{ isCopied(account.number, 'all') ? copiedAllButtonLabel : copyAllButtonLabel }}
+                  {{ isCopied(account.number, 'all') ? copiedAllLabel : copyAllLabel }}
                 </span>
                 <i
                   v-if="isCopied(account.number, 'all')"

--- a/frontend/src/payments/composables/useLocalizedSections.ts
+++ b/frontend/src/payments/composables/useLocalizedSections.ts
@@ -65,7 +65,7 @@ export const useLocalizedSections = (
           .map((method) => ({
             ...method,
             category,
-            name: i18nStore.t(`payment.${method.id}.name`),
+            name: i18nStore.t(`options.${method.id}`),
             isSelected: method.id === selectedMethodId.value,
           }))
           .filter((method) => method.name),

--- a/frontend/src/payments/stores/paymentInteraction.store.ts
+++ b/frontend/src/payments/stores/paymentInteraction.store.ts
@@ -92,7 +92,7 @@ export const usePaymentInteractionStore = defineStore('payment-interaction', () 
       return template
     }
 
-    const providerLabel = i18nStore.t(`payment.${provider}.name`, provider)
+    const providerLabel = i18nStore.t(`options.${provider}`, provider)
 
     return template.split('{provider}').join(providerLabel)
   }
@@ -102,14 +102,13 @@ export const usePaymentInteractionStore = defineStore('payment-interaction', () 
     provider: DeepLinkProvider,
     options: DeepLinkDialogOptions = {},
   ) => {
-    const baseKey = 'dialogs.deepLink'
-    const keySuffix = type === 'not-mobile' ? 'notMobile' : 'notInstalled'
-    const messageKey = `${baseKey}.description.${keySuffix}`
+    const baseKey = type === 'not-mobile' ? 'dialogs.notMobile' : 'dialogs.notInstalled'
+    const messageKey = `${baseKey}.description`
 
     dialogContent.value = {
       type,
       provider,
-      title: i18nStore.t(`${baseKey}.titles.${keySuffix}`),
+      title: i18nStore.t(`${baseKey}.title`),
       message: formatProviderMessage(messageKey, provider),
       confirmLabel: i18nStore.t('dialogs.confirm'),
       deepLinkUrl: options.deepLinkUrl ?? null,


### PR DESCRIPTION
## Summary
- move the transfer dialog's currency-suffixed amount text into localized messages for each locale
- reuse a shared formatter in TransferAccountsDialog to build both display and copy payload amounts from the localized template
- flatten the payment method translations into a new `options` namespace and remove unused CTA/name keys
- update the deep link dialog copy to mention each provider's app in every locale
- point payment experiences at the `options` namespace for provider labels
- restructure the deep link troubleshooting dialogs into `notMobile`/`notInstalled` groups and wire the app to the new keys

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df563c3b68832cae702a7ce8ebb3c2