### PR TITLE
Update notMobile localization description to reference method links

### DIFF
--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -15,7 +15,7 @@
     "confirm": "OK",
     "notMobile": {
       "title": "Open on your mobile device",
-      "description": "The {provider} transfer link only opens in the mobile app. Please continue on your phone."
+      "description": "The {method} link only opens on mobile. Please continue on your phone."
     },
     "notInstalled": {
       "title": "Having trouble opening the app?",

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -15,7 +15,7 @@
     "confirm": "OK",
     "notMobile": {
       "title": "モバイル専用です",
-      "description": "{provider}送金リンクはモバイルアプリでのみ開けます。スマートフォンで再度お試しください。"
+      "description": "{method}リンクはモバイルアプリでのみ開きます。スマートフォンで再度お試しください。"
     },
     "notInstalled": {
       "title": "アプリが起動しませんか？",

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -15,7 +15,7 @@
     "confirm": "확인",
     "notMobile": {
       "title": "모바일에서만 이용할 수 있어요",
-      "description": "{provider} 송금링크는 모바일에서만 열려요. 휴대폰에서 다시 시도해 주세요."
+      "description": "{method} 링크는 모바일에서만 열려요. 휴대폰에서 다시 시도해 주세요."
     },
     "notInstalled": {
       "title": "앱이 실행되지 않았나요?",

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -15,7 +15,7 @@
     "confirm": "好的",
     "notMobile": {
       "title": "仅限移动设备使用",
-      "description": "{provider} 链接只能在移动设备上打开。请在手机上重试。"
+      "description": "{method} 链接只能在移动设备上打开。请在手机上重试。"
     },
     "notInstalled": {
       "title": "应用没有打开吗？",


### PR DESCRIPTION
## Summary
- update the notMobile dialog description in all supported locales to refer to the method link instead of the provider

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df5e0b81fc832cab5c1442d89b532e