### PR TITLE
Simplify transfer amount localization and formatting

### DIFF
--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -24,8 +24,7 @@
     },
     "transferAccounts": {
       "title": "Bank transfer details",
-      "description": "Send {amountWithCurrency} to one of the accounts below.",
-      "amountWithCurrency": "{amount} KRW",
+      "description": "Send {amount} to one of the accounts below.",
       "copy": {
         "all": "Copy transfer details",
         "accountNo": "Copy only account number"

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -24,8 +24,7 @@
     },
     "transferAccounts": {
       "title": "口座振込のご案内",
-      "description": "下記のいずれかの口座へ {amountWithCurrency} をお振り込みください。",
-      "amountWithCurrency": "{amount} KRW",
+      "description": "下記のいずれかの口座へ {amount} をお振り込みください。",
       "copy": {
         "all": "振込情報をコピー",
         "accountNo": "口座番号のみコピー"

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -24,8 +24,7 @@
     },
     "transferAccounts": {
       "title": "계좌이체 정보",
-      "description": "{amountWithCurrency} 금액을 아래 계좌 중 하나로 보내 주세요.",
-      "amountWithCurrency": "{amount}원",
+      "description": "{amount}을 아래 계좌 중 하나로 보내 주세요.",
       "copy": {
         "all": "이체 정보 복사",
         "accountNo": "계좌번호만 복사"

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -24,8 +24,7 @@
     },
     "transferAccounts": {
       "title": "银行转账信息",
-      "description": "请将 {amountWithCurrency} 转入下方任一账户。",
-      "amountWithCurrency": "{amount} 韩元",
+      "description": "请将 {amount} 转入下方任一账户。",
       "copy": {
         "all": "复制转账信息",
         "accountNo": "仅复制账号"

--- a/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
+++ b/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
@@ -27,31 +27,23 @@ const { locale } = storeToRefs(i18nStore)
 const { isCopied, isTooltipVisible, setHoveredControl, handleCopyAll, handleCopyNumber, reset } =
   useTransferCopyState()
 
-const localeNumberFormats: Record<string, string> = {
-  en: 'en-US',
-  ko: 'ko-KR',
-  ja: 'ja-JP',
-  zh: 'zh-CN',
-}
-
-const numberFormatter = computed(() => new Intl.NumberFormat(localeNumberFormats[locale.value] ?? 'en-US'))
-const formattedAmount = computed(() => numberFormatter.value.format(props.amount))
-
-const formattedAmountForCopy = computed(() => new Intl.NumberFormat('ko-KR').format(props.amount))
-
-const formatAmountWithCurrency = (value: string) =>
-  i18nStore.t('dialogs.transferAccounts.amountWithCurrency').replace('{amount}', value)
-
-const amountWithCurrency = computed(() => formatAmountWithCurrency(formattedAmount.value))
-const amountWithCurrencyForCopy = computed(() => formatAmountWithCurrency(formattedAmountForCopy.value))
+const formattedAmount = computed(() =>
+  props.amount
+    .toLocaleString(locale.value || 'en', {
+      style: 'currency',
+      currency: 'KRW',
+      maximumFractionDigits: 0,
+    })
+    .replace(/\u00A0/g, ' '),
+)
 
 const title = computed(() => i18nStore.t('dialogs.transferAccounts.title'))
 const descriptionHtml = computed(() =>
   i18nStore
     .t('dialogs.transferAccounts.description')
     .replace(
-      '{amountWithCurrency}',
-      `<strong class="font-semibold text-roadshop-primary">${amountWithCurrency.value}</strong>`,
+      '{amount}',
+      `<strong class="font-semibold text-roadshop-primary">${formattedAmount.value}</strong>`,
     ),
 )
 const copyAllLabel = computed(() => i18nStore.t('dialogs.transferAccounts.copy.all'))
@@ -62,7 +54,7 @@ const copiedNumberLabel = computed(() => i18nStore.t('dialogs.transferAccounts.c
 const getIconForBank = (bank: string) => getFirmIcon(bank)
 
 const copyTransferDetails = async (account: TransferAccount) => {
-  const amountText = amountWithCurrencyForCopy.value
+  const amountText = formattedAmount.value
   const payload = `${account.bank} ${account.number} ${account.holder} [${amountText}]`
   await handleCopyAll(account.number, payload)
 }


### PR DESCRIPTION
## Summary
- inline the transfer amount placeholders into the transfer accounts dialog descriptions for each locale
- simplify TransferAccountsDialog amount formatting by using locale-aware currency output and reusing it for clipboard payloads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df696eb180832cb5ad805027355076