### PR TITLE
Highlight bank transfer messaging in localization

### DIFF
--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -24,7 +24,7 @@
     },
     "transferAccounts": {
       "title": "Bank transfer details",
-      "description": "Send {amount} to one of the accounts below.",
+      "description": "Send <strong class=\"text-roadshop-accent\">₩{amount}</strong> to one of the accounts below.",
       "copy": {
         "all": "Copy transfer details",
         "accountNo": "Copy only account number"
@@ -40,7 +40,7 @@
     },
     "tossInstruction": {
       "title": "Send with Toss",
-      "description": "We've <strong>automatically copied</strong> the account details you need for Toss.",
+      "description": "We've <strong class=\"text-roadshop-accent\">automatically copied</strong> the account details you need for Toss.",
       "launchCta": "Go to Toss",
       "reopen": "Reopen Toss"
     }

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -24,7 +24,7 @@
     },
     "transferAccounts": {
       "title": "口座振込のご案内",
-      "description": "下記のいずれかの口座へ {amount} をお振り込みください。",
+      "description": "下記のいずれかの口座へ <strong class=\"text-roadshop-accent\">₩{amount}</strong> をお振り込みください。",
       "copy": {
         "all": "振込情報をコピー",
         "accountNo": "口座番号のみコピー"
@@ -40,7 +40,7 @@
     },
     "tossInstruction": {
       "title": "Tossで送金",
-      "description": "送金に必要な口座情報を<strong>自動でコピー</strong>しました。",
+      "description": "送金に必要な口座情報を<strong class=\"text-roadshop-accent\">自動でコピー</strong>しました。",
       "launchCta": "Tossへ移動",
       "reopen": "Tossをもう一度開く"
     }

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -24,7 +24,7 @@
     },
     "transferAccounts": {
       "title": "계좌이체 정보",
-      "description": "{amount}을 아래 계좌 중 하나로 보내 주세요.",
+      "description": "<strong class=\"text-roadshop-accent\">₩{amount}</strong>을 아래 계좌 중 하나로 보내 주세요.",
       "copy": {
         "all": "이체 정보 복사",
         "accountNo": "계좌번호만 복사"
@@ -40,7 +40,7 @@
     },
     "tossInstruction": {
       "title": "토스로 송금하기",
-      "description": "송금에 필요한 계좌 정보를 <strong>자동으로 복사</strong>해 두었어요.",
+      "description": "송금에 필요한 계좌 정보를 <strong class=\"text-roadshop-accent\">자동으로 복사</strong>해 두었어요.",
       "launchCta": "토스로 이동하기",
       "reopen": "토스 다시열기"
     }

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -24,7 +24,7 @@
     },
     "transferAccounts": {
       "title": "银行转账信息",
-      "description": "请将 {amount} 转入下方任一账户。",
+      "description": "请将 <strong class=\"text-roadshop-accent\">₩{amount}</strong> 转入下方任一账户。",
       "copy": {
         "all": "复制转账信息",
         "accountNo": "仅复制账号"
@@ -40,7 +40,7 @@
     },
     "tossInstruction": {
       "title": "使用 Toss 转账",
-      "description": "已将转账所需的账户信息<strong>自动复制</strong>好了。",
+      "description": "已将转账所需的账户信息<strong class=\"text-roadshop-accent\">自动复制</strong>好了。",
       "launchCta": "前往 Toss",
       "reopen": "重新打开 Toss"
     }

--- a/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
+++ b/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
@@ -28,12 +28,12 @@ const { isCopied, isTooltipVisible, setHoveredControl, handleCopyAll, handleCopy
   useTransferCopyState()
   
 const title = computed(() => i18nStore.t('dialogs.transferAccounts.title'))
+const formattedAmount = computed(() => props.amount.toLocaleString(locale.value || 'ko-KR'))
+
 const descriptionHtml = computed(() =>
-  i18nStore.t('dialogs.transferAccounts.description')
-    .replace(
-      '{amount}',
-      `<strong class="font-semibold text-roadshop-primary">₩${props.amount.toLocaleString(locale.value || 'ko-KR')}</strong>`,
-    ),
+  i18nStore
+    .t('dialogs.transferAccounts.description')
+    .replace('{amount}', formattedAmount.value),
 )
 
 const copyAllLabel = computed(() => i18nStore.t('dialogs.transferAccounts.copy.all'))

--- a/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
+++ b/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
@@ -28,12 +28,9 @@ const { isCopied, isTooltipVisible, setHoveredControl, handleCopyAll, handleCopy
   useTransferCopyState()
   
 const title = computed(() => i18nStore.t('dialogs.transferAccounts.title'))
-const formattedAmount = computed(() => props.amount.toLocaleString(locale.value || 'ko-KR'))
-
 const descriptionHtml = computed(() =>
-  i18nStore
-    .t('dialogs.transferAccounts.description')
-    .replace('{amount}', formattedAmount.value),
+  i18nStore.t('dialogs.transferAccounts.description')
+    .replace('{amount}', props.amount.toLocaleString(locale.value || 'ko-KR')),
 )
 
 const copyAllLabel = computed(() => i18nStore.t('dialogs.transferAccounts.copy.all'))


### PR DESCRIPTION
## Summary
- add accent styling to the bank transfer amount across all localized messages
- update copy instructions to use the accent highlight in every locale
- adjust the transfer dialog to defer styling to the localized HTML

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df90a615c0832c99501d881f52685a