### PR TITLE
Generalize branding for reusable payment component

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,8 +1,8 @@
-# Road Shop Pay Frontend
+# Universal Payment Component Frontend
 
-A Vue 3 + Vite single-page experience that guides visitors at Korean street shops to the right QR payment option. The
-site now starts in English, automatically follows the browser language when possible, and lets guests switch between
-English, Korean, and Japanese manually.
+A Vue 3 + Vite single-page experience that guides visitors to the right QR payment option. The site now starts in
+English, automatically follows the browser language when possible, and lets guests switch between English, Korean, and
+Japanese manually.
 
 ## Tech stack
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <meta name="format-detection" content="telephone=no">
     <meta
       name="description"
-      content="길거리 상점 QR 결제 지원 서비스. 카카오송금과 토스송금 KRW 결제와 글로벌 결제를 한 번에 준비하세요."
+      content="다양한 상점 환경에 적용할 수 있는 재사용 가능한 결제 선택 컴포넌트입니다."
     >
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -14,9 +14,9 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
     >
-    <title>Road Shop Pay</title>
+    <title>Universal Payment Component</title>
   </head>
-  <body class="bg-roadshop-highlight">
+  <body class="bg-brand-highlight">
     <div id="app"></div>
     <script type="module" src="./src/main.ts"></script>
   </body>

--- a/frontend/src/app/App.vue
+++ b/frontend/src/app/App.vue
@@ -3,7 +3,7 @@ import Experience from '@/payments/components/Experience.vue'
 </script>
 
 <template>
-  <div class="flex min-h-screen flex-col bg-roadshop-highlight/40">
+  <div class="flex min-h-screen flex-col bg-brand-highlight/40">
     <main class="mx-auto w-full max-w-5xl flex-1 px-6 py-12">
       <Experience />
     </main>

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -7,5 +7,5 @@
 }
 
 body {
-  @apply bg-roadshop-highlight text-roadshop-primary min-h-screen font-sans antialiased;
+  @apply bg-brand-highlight text-brand-primary min-h-screen font-sans antialiased;
 }

--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -24,7 +24,7 @@
     },
     "transferAccounts": {
       "title": "Bank transfer details",
-      "description": "Send <strong class=\"text-roadshop-accent\">₩{amount}</strong> to one of the accounts below.",
+      "description": "Send <strong class=\"text-brand-accent\">₩{amount}</strong> to one of the accounts below.",
       "copy": {
         "all": "Copy transfer details",
         "accountNo": "Copy only account number"
@@ -40,7 +40,7 @@
     },
     "tossInstruction": {
       "title": "Send with Toss",
-      "description": "We've <strong class=\"text-roadshop-accent\">automatically copied</strong> the account details you need for Toss.",
+      "description": "We've <strong class=\"text-brand-accent\">automatically copied</strong> the account details you need for Toss.",
       "launchCta": "Go to Toss",
       "reopen": "Reopen Toss"
     }

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -24,7 +24,7 @@
     },
     "transferAccounts": {
       "title": "口座振込のご案内",
-      "description": "下記のいずれかの口座へ <strong class=\"text-roadshop-accent\">₩{amount}</strong> をお振り込みください。",
+      "description": "下記のいずれかの口座へ <strong class=\"text-brand-accent\">₩{amount}</strong> をお振り込みください。",
       "copy": {
         "all": "振込情報をコピー",
         "accountNo": "口座番号のみコピー"
@@ -40,7 +40,7 @@
     },
     "tossInstruction": {
       "title": "Tossで送金",
-      "description": "送金に必要な口座情報を<strong class=\"text-roadshop-accent\">自動でコピー</strong>しました。",
+      "description": "送金に必要な口座情報を<strong class=\"text-brand-accent\">自動でコピー</strong>しました。",
       "launchCta": "Tossへ移動",
       "reopen": "Tossをもう一度開く"
     }

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -24,7 +24,7 @@
     },
     "transferAccounts": {
       "title": "계좌이체 정보",
-      "description": "<strong class=\"text-roadshop-accent\">₩{amount}</strong>을 아래 계좌 중 하나로 보내 주세요.",
+      "description": "<strong class=\"text-brand-accent\">₩{amount}</strong>을 아래 계좌 중 하나로 보내 주세요.",
       "copy": {
         "all": "이체 정보 복사",
         "accountNo": "계좌번호만 복사"
@@ -40,7 +40,7 @@
     },
     "tossInstruction": {
       "title": "토스로 송금하기",
-      "description": "송금에 필요한 계좌 정보를 <strong class=\"text-roadshop-accent\">자동으로 복사</strong>해 두었어요.",
+      "description": "송금에 필요한 계좌 정보를 <strong class=\"text-brand-accent\">자동으로 복사</strong>해 두었어요.",
       "launchCta": "토스로 이동하기",
       "reopen": "토스 다시열기"
     }

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -24,7 +24,7 @@
     },
     "transferAccounts": {
       "title": "银行转账信息",
-      "description": "请将 <strong class=\"text-roadshop-accent\">₩{amount}</strong> 转入下方任一账户。",
+      "description": "请将 <strong class=\"text-brand-accent\">₩{amount}</strong> 转入下方任一账户。",
       "copy": {
         "all": "复制转账信息",
         "accountNo": "仅复制账号"
@@ -40,7 +40,7 @@
     },
     "tossInstruction": {
       "title": "使用 Toss 转账",
-      "description": "已将转账所需的账户信息<strong class=\"text-roadshop-accent\">自动复制</strong>好了。",
+      "description": "已将转账所需的账户信息<strong class=\"text-brand-accent\">自动复制</strong>好了。",
       "launchCta": "前往 Toss",
       "reopen": "重新打开 Toss"
     }

--- a/frontend/src/payments/components/AccountInfoCard.vue
+++ b/frontend/src/payments/components/AccountInfoCard.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-
 import { getFirmIcon } from '@icons/firms'
 import type { TransferAccount } from '@/payments/services/paymentInfoService'
 
@@ -16,14 +14,14 @@ const props = defineProps<Props>()
     <div class="flex flex-col items-center gap-7 text-center">
       <div class="flex flex-col items-center gap-5">
         <div
-          class="flex h-20 w-20 items-center justify-center rounded-3xl bg-roadshop-highlight/60 shadow-inner"
+          class="flex h-20 w-20 items-center justify-center rounded-3xl bg-brand-highlight/60 shadow-inner"
           aria-hidden="true"
         >
           <img :src="getFirmIcon(props.account.bank)" :alt="props.account.bank" class="h-14 w-14" />
         </div>
         <div>
-          <p class="text-2xl font-semibold text-roadshop-primary">
-            {{ props.account.bank }}<span class="ml-2 text-lg font-medium text-roadshop-primary/80">({{ props.account.holder }})</span>
+          <p class="text-2xl font-semibold text-brand-primary">
+            {{ props.account.bank }}<span class="ml-2 text-lg font-medium text-brand-primary/80">({{ props.account.holder }})</span>
           </p>
           <p class="mt-3 font-mono text-lg tracking-wider text-slate-700">{{ props.account.number }}</p>
         </div>

--- a/frontend/src/payments/components/CurrencySelectorDialog.vue
+++ b/frontend/src/payments/components/CurrencySelectorDialog.vue
@@ -45,11 +45,11 @@ const onClose = () => {
         v-for="currency in props.currencies"
         :key="currency"
         type="button"
-        class="flex items-center justify-between rounded-xl border border-roadshop-primary/20 px-4 py-3 text-roadshop-primary transition hover:border-roadshop-accent hover:bg-roadshop-highlight/60"
+        class="flex items-center justify-between rounded-xl border border-brand-primary/20 px-4 py-3 text-brand-primary transition hover:border-brand-accent hover:bg-brand-highlight/60"
         @click="onSelectCurrency(currency)"
       >
         <span class="text-sm font-semibold">{{ currency }}</span>
-        <span aria-hidden="true" class="text-roadshop-accent">→</span>
+        <span aria-hidden="true" class="text-brand-accent">→</span>
       </button>
     </div>
   </DialogCloseFull>

--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -21,6 +21,10 @@ import type {
   PaymentMethodWithCurrencies,
 } from '@/payments/types'
 
+defineOptions({
+  name: 'PaymentExperience',
+})
+
 const paymentStore = usePaymentStore()
 const paymentInteractionStore = usePaymentInteractionStore()
 const i18nStore = useI18nStore()
@@ -155,13 +159,13 @@ const onLaunchTossInstructionDialog = () => {
       v-else-if="!hasVisibleMethods && areMethodsLoading"
       class="flex justify-center py-12"
     >
-      <span class="text-sm text-roadshop-primary/70">{{ i18nStore.t('status.loading.methods') }}</span>
+      <span class="text-sm text-brand-primary/70">{{ i18nStore.t('status.loading.methods') }}</span>
     </div>
     <div
       v-else-if="!hasVisibleMethods"
       class="flex justify-center py-12"
     >
-      <span class="text-sm text-roadshop-primary/70">{{ i18nStore.t('status.empty') }}</span>
+      <span class="text-sm text-brand-primary/70">{{ i18nStore.t('status.empty') }}</span>
     </div>
     <template v-else>
       <Section

--- a/frontend/src/payments/components/OptionCard.vue
+++ b/frontend/src/payments/components/OptionCard.vue
@@ -53,7 +53,7 @@ onBeforeUnmount(() => {
 <template>
   <article
     class="group flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white/80 p-6 text-left shadow-sm backdrop-blur transition hover:-translate-y-1 hover:shadow-lg focus:outline-none cursor-pointer"
-    :class="props.isSelected ? 'ring-2 ring-roadshop-accent' : ''"
+    :class="props.isSelected ? 'ring-2 ring-brand-accent' : ''"
     role="button"
     tabindex="0"
     @click="emit('select')"
@@ -76,7 +76,7 @@ onBeforeUnmount(() => {
           </div>
         </div>
         <div class="flex flex-1 items-center">
-          <h3 class="text-xl font-semibold text-roadshop-primary">
+          <h3 class="text-xl font-semibold text-brand-primary">
             {{ props.name }}
           </h3>
         </div>
@@ -85,12 +85,12 @@ onBeforeUnmount(() => {
 
     <div
       v-if="props.category !== 'KRW' && props.supportedCurrencies.length"
-      class="flex flex-wrap gap-2 text-xs text-roadshop-primary"
+      class="flex flex-wrap gap-2 text-xs text-brand-primary"
     >
       <span
         v-for="currency in props.supportedCurrencies"
         :key="currency"
-        class="inline-flex items-center gap-1 rounded-full border border-roadshop-primary/20 bg-roadshop-highlight/60 px-3 py-1 font-semibold"
+        class="inline-flex items-center gap-1 rounded-full border border-brand-primary/20 bg-brand-highlight/60 px-3 py-1 font-semibold"
       >
         {{ currency }}
       </span>

--- a/frontend/src/payments/components/Section.vue
+++ b/frontend/src/payments/components/Section.vue
@@ -7,7 +7,11 @@ interface Props {
   title: string
 }
 
-const props = defineProps<Props>()
+defineOptions({
+  name: 'PaymentMethodSection',
+})
+
+const { section, title } = defineProps<Props>()
 
 const emit = defineEmits<{
   select: [string]
@@ -17,7 +21,7 @@ const emit = defineEmits<{
 <template>
   <section class="flex flex-col gap-5">
     <div class="flex flex-col gap-2">
-      <h2 class="text-2xl font-semibold text-roadshop-primary">{{ title }}</h2>
+      <h2 class="text-2xl font-semibold text-brand-primary">{{ title }}</h2>
     </div>
     <div class="grid gap-3 md:grid-cols-2">
       <OptionCard

--- a/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
+++ b/frontend/src/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue
@@ -7,7 +7,7 @@ import type { TransferAccount } from '@/payments/services/paymentInfoService'
 import TooltipBubble from '@/shared/components/TooltipBubble.vue'
 import DialogCloseFull from '@/shared/components/DialogCloseFull.vue'
 import { getFirmIcon } from '@icons/firms'
-import { useTransferCopyState, type CopyAction } from './useTransferCopyState'
+import { useTransferCopyState } from './useTransferCopyState'
 
 interface Props {
   visible: boolean
@@ -66,7 +66,7 @@ watch(
         class="overflow-hidden rounded-2xl border border-slate-200 shadow-sm"
       >
         <div class="flex w-full flex-col items-stretch sm:flex-row sm:items-stretch">
-          <div class="flex flex-1 items-start gap-3 bg-roadshop-highlight/40 p-4">
+          <div class="flex flex-1 items-start gap-3 bg-brand-highlight/40 p-4">
             <div
               v-if="getFirmIcon(account.bank)"
               class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-white shadow"
@@ -75,13 +75,13 @@ watch(
             </div>
             <div>
               <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-                <p class="text-base font-semibold text-roadshop-primary">{{ account.bank }}</p>
+                <p class="text-base font-semibold text-brand-primary">{{ account.bank }}</p>
                 <p class="text-xs text-slate-500">{{ account.holder }}</p>
               </div>
               <div class="relative mt-1">
                 <button
                   type="button"
-                  class="group inline-flex items-center gap-1 font-mono text-sm text-roadshop-primary"
+                  class="group inline-flex items-center gap-1 font-mono text-sm text-brand-primary"
                   @click="handleCopyNumber(account)"
                   @mouseenter="setHoveredControl(account, 'number', true)"
                   @mouseleave="setHoveredControl(account, 'number', false)"
@@ -95,7 +95,7 @@ watch(
                     :class="
                       isCopied(account, 'number')
                         ? ['pi-check', 'text-emerald-500', 'group-hover:text-emerald-500']
-                        : ['pi-copy', 'text-roadshop-primary', 'group-hover:text-roadshop-primary']
+                        : ['pi-copy', 'text-brand-primary', 'group-hover:text-brand-primary']
                     "
                   ></i>
                 </button>
@@ -114,7 +114,7 @@ watch(
                 'flex h-full min-h-[45px] w-full items-center justify-center gap-2 px-5 text-sm font-semibold text-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 sm:min-w-[64px]',
                 isCopied(account, 'all')
                   ? 'bg-emerald-500 hover:bg-emerald-500 focus-visible:outline-emerald-500'
-                  : 'bg-roadshop-primary hover:bg-roadshop-primary/90 focus-visible:outline-roadshop-primary',
+                  : 'bg-brand-primary hover:bg-brand-primary/90 focus-visible:outline-brand-primary',
               ]"
               :aria-label="copyAllLabel"
               @click="handleCopyAll(account, props.amount)"

--- a/frontend/src/payments/services/paymentInfoService.ts
+++ b/frontend/src/payments/services/paymentInfoService.ts
@@ -42,7 +42,7 @@ export type PaymentMethodDetail =
   | { type: 'url'; data: MethodUrlInfo }
 
 const DEFAULT_API_BASE_URL =
-  'https://raw.githubusercontent.com/EedoCelsius/roadshop/refs/heads/main/backend/response'
+  'https://raw.githubusercontent.com/EedoCelsius/payment-component/refs/heads/main/backend/response'
 
 const normalizeBaseUrl = (value: string): string => value.replace(/\/+$/, '')
 const normalizePath = (value: string): string => value.replace(/^\/+/, '')

--- a/frontend/src/shared/components/DialogBase.vue
+++ b/frontend/src/shared/components/DialogBase.vue
@@ -30,7 +30,7 @@ const onClose = () => {
       >
         <div class="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl" @click.stop>
           <header class="space-y-2">
-            <h3 class="text-lg font-semibold text-roadshop-primary">{{ props.title }}</h3>
+            <h3 class="text-lg font-semibold text-brand-primary">{{ props.title }}</h3>
             <p v-if="props.description" class="text-sm text-slate-600" v-html="props.description"></p>
           </header>
           <div class="mt-6">

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,7 +7,7 @@ export default {
   theme: {
     extend: {
       colors: {
-        roadshop: {
+        brand: {
           primary: "#111827",
           accent: "#00C896",
           highlight: "#F3F4F6",


### PR DESCRIPTION
## Summary
- replace Road Shop specific branding, colors, and copy with neutral component naming
- update Tailwind color palette and all related class names to use the new brand namespace
- refresh localized strings, documentation, and default data URL to remove roadshop references

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfc120ea7c832ca78d2685bb7aab78