### PR TITLE
Adjust QR hint wording for Chinese and Japanese locales

### DIFF
--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -16,7 +16,7 @@
     "notMobile": {
       "title": "モバイル専用です",
       "description": "{method}リンクはモバイルアプリでのみ開きます。スマートフォンで再度お試しください。",
-      "qrHint": "QRコードをスキャンして{method}アプリに移動します"
+      "qrHint": "読み取って{method}アプリに移動します"
     },
     "notInstalled": {
       "title": "アプリが起動しませんか？",

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -16,7 +16,7 @@
     "notMobile": {
       "title": "仅限移动设备使用",
       "description": "{method} 链接只能在移动设备上打开。请在手机上重试。",
-      "qrHint": "扫描二维码前往 {method} 应用"
+      "qrHint": "扫描前往 {method} 应用"
     },
     "notInstalled": {
       "title": "应用没有打开吗？",


### PR DESCRIPTION
## Summary
- update the Chinese `qrHint` copy to omit the explicit QR code reference
- adjust the Japanese `qrHint` phrasing to remove the QR code term while keeping natural wording

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dff10a3218832caf049e0bef6045b6