### PR TITLE
Handle dialog routes for payment experiences

### DIFF
--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 
 import LoadingOverlay from '@/shared/components/LoadingOverlay.vue'
@@ -30,6 +30,115 @@ const { methods, selectedMethod, selectedCurrency, isCurrencySelectorOpen, isLoa
 const tossExperienceRef = ref<InstanceType<typeof TossExperience> | null>(null)
 const kakaoExperienceRef = ref<InstanceType<typeof KakaoExperience> | null>(null)
 const transferExperienceRef = ref<InstanceType<typeof TransferExperience> | null>(null)
+
+const resolveBasePath = (): string => {
+  if (typeof window === 'undefined') {
+    return '/'
+  }
+
+  try {
+    const url = new URL(import.meta.env.BASE_URL ?? '/', window.location.origin)
+    const trimmedPath = url.pathname.replace(/\/+$/, '')
+    return trimmedPath || '/'
+  } catch (error) {
+    console.error('Failed to resolve base path', error)
+    return '/'
+  }
+}
+
+const getMethodFromPath = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  const segments = window.location.pathname.split('/').filter(Boolean)
+  return segments.length ? segments[segments.length - 1] : null
+}
+
+let lastHandledPath: string | null = null
+let activeRouteMethod: string | null = null
+let isProcessingRoute = false
+
+const handleRouteNavigation = async () => {
+  if (typeof window === 'undefined' || isProcessingRoute || areMethodsLoading.value) {
+    return
+  }
+
+  const currentPath = window.location.pathname
+  const candidateMethod = getMethodFromPath()
+
+  if (!candidateMethod || !methods.value.some((method) => method.id === candidateMethod)) {
+    activeRouteMethod = null
+    lastHandledPath = currentPath
+    return
+  }
+
+  if (lastHandledPath === currentPath && activeRouteMethod === candidateMethod) {
+    return
+  }
+
+  const method = paymentStore.getMethodById(candidateMethod)
+
+  if (!method) {
+    return
+  }
+
+  isProcessingRoute = true
+  lastHandledPath = currentPath
+  activeRouteMethod = candidateMethod
+
+  paymentStore.selectMethod(candidateMethod)
+
+  try {
+    if (!isCurrencySelectorOpen.value) {
+      await runWorkflowForMethod(method, selectedCurrency.value)
+    }
+  } finally {
+    isProcessingRoute = false
+  }
+}
+
+const navigateToBasePath = () => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const targetPath = resolveBasePath()
+
+  try {
+    window.history.replaceState({}, '', targetPath)
+  } catch (error) {
+    console.error('Failed to navigate to base path', error)
+  }
+
+  lastHandledPath = window.location.pathname
+  activeRouteMethod = null
+}
+
+const onExperienceClose = () => {
+  navigateToBasePath()
+}
+
+const onPopState = () => {
+  void handleRouteNavigation()
+}
+
+watch(
+  [methods, () => areMethodsLoading.value],
+  () => {
+    void handleRouteNavigation()
+  },
+  { immediate: true },
+)
+
+onMounted(() => {
+  window.addEventListener('popstate', onPopState)
+  void handleRouteNavigation()
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('popstate', onPopState)
+})
 
 const categorizeMethod = (method: PaymentMethodWithCurrencies): PaymentCategory =>
   method.supportedCurrencies.some((currency) => currency !== 'KRW') ? 'GLOBAL' : 'KRW'
@@ -158,9 +267,9 @@ const onCloseCurrencySelector = () => {
       @select="onCurrencySelect"
       @close="onCloseCurrencySelector"
     />
-    <TransferExperience ref="transferExperienceRef" />
-    <TossExperience ref="tossExperienceRef" />
-    <KakaoExperience ref="kakaoExperienceRef" />
+    <TransferExperience ref="transferExperienceRef" @close="onExperienceClose" />
+    <TossExperience ref="tossExperienceRef" @close="onExperienceClose" />
+    <KakaoExperience ref="kakaoExperienceRef" @close="onExperienceClose" />
     <LoadingOverlay
       :visible="isDeepLinkChecking"
       :message="i18nStore.t('status.loading.deepLink')"

--- a/frontend/src/payments/components/kakao/KakaoExperience.vue
+++ b/frontend/src/payments/components/kakao/KakaoExperience.vue
@@ -11,6 +11,12 @@ const paymentInfoStore = usePaymentInfoStore()
 const notMobileDialogRef = ref<InstanceType<typeof IsNotMobileDialog> | null>(null)
 const notInstalledDialogRef = ref<InstanceType<typeof IsNotInstalledDialog> | null>(null)
 
+const emit = defineEmits<{ close: [] }>()
+
+const onDialogClose = () => {
+  emit('close')
+}
+
 const run = async (): Promise<boolean> => {
   const ready = await paymentInfoStore.ensureMethodInfo('kakao')
 
@@ -47,6 +53,6 @@ defineExpose({
 </script>
 
 <template>
-  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" @close="onDialogClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" @close="onDialogClose" />
 </template>

--- a/frontend/src/payments/components/toss/TossExperience.vue
+++ b/frontend/src/payments/components/toss/TossExperience.vue
@@ -17,6 +17,8 @@ const tossDeepLinkUrl = ref<string | null>(null)
 const notMobileDialogRef = ref<InstanceType<typeof IsNotMobileDialog> | null>(null)
 const notInstalledDialogRef = ref<InstanceType<typeof IsNotInstalledDialog> | null>(null)
 
+const emit = defineEmits<{ close: [] }>()
+
 const tossInfo = computed(() => paymentInfoStore.tossInfo)
 
 const countdownManager = createCountdownManager((remainingSeconds) => {
@@ -33,6 +35,10 @@ const closeInstructionDialog = () => {
   isInstructionVisible.value = false
   tossInstructionCountdown.value = 0
   tossDeepLinkUrl.value = null
+}
+
+const emitClose = () => {
+  emit('close')
 }
 
 const showInstructionDialog = async (seconds: number): Promise<boolean> => {
@@ -85,6 +91,7 @@ const run = async (): Promise<boolean> => {
 
 const onInstructionClose = () => {
   closeInstructionDialog()
+  emitClose()
 }
 
 const onInstructionLaunchNow = () => {
@@ -97,6 +104,10 @@ const onInstructionReopen = () => {
   }
 
   void runDeepLink(tossDeepLinkUrl.value)
+}
+
+const onDialogClose = () => {
+  emitClose()
 }
 
 defineExpose({
@@ -113,6 +124,6 @@ defineExpose({
     @launch-now="onInstructionLaunchNow"
     @reopen="onInstructionReopen"
   />
-  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" @close="onDialogClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" @close="onDialogClose" />
 </template>

--- a/frontend/src/payments/components/transfer/TransferExperience.vue
+++ b/frontend/src/payments/components/transfer/TransferExperience.vue
@@ -10,6 +10,8 @@ const isDialogVisible = ref(false)
 const transferAmount = computed(() => paymentInfoStore.transferInfo?.amount.krw ?? 0)
 const transferAccounts = computed(() => paymentInfoStore.transferInfo?.account ?? [])
 
+const emit = defineEmits<{ close: [] }>()
+
 const openDialog = async (): Promise<boolean> => {
   const ready = await paymentInfoStore.ensureMethodInfo('transfer')
 
@@ -27,6 +29,7 @@ const closeDialog = () => {
 
 const onClose = () => {
   closeDialog()
+  emit('close')
 }
 
 defineExpose({


### PR DESCRIPTION
## Summary
- trigger payment workflows when visiting method-specific URLs
- bubble dialog close events from toss, kakao, and transfer experiences
- reset the browser URL back to the base path when dialogs close

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dffd542ee0832c88666fb03ae278ed