### PR TITLE
Handle payment dialogs from URL routes

### DIFF
--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 
 import LoadingOverlay from '@/shared/components/LoadingOverlay.vue'
@@ -15,6 +15,11 @@ import { useI18nStore } from '@/localization/store'
 import { isDeepLinkChecking } from '@/payments/services/deepLinkService'
 import { openUrlInNewTab } from '@/shared/utils/navigation'
 import type { PaymentCategory, PaymentMethodWithCurrencies } from '@/payments/types'
+
+interface RouteCandidate {
+  methodId: string
+  basePath: string
+}
 
 defineOptions({
   name: 'PaymentExperience',
@@ -61,29 +66,32 @@ const openMethodUrl = async (method: PaymentMethodWithCurrencies, currency: stri
   const ready = await paymentInfoStore.ensureMethodInfo(method.id)
 
   if (!ready) {
-    return
+    return false
   }
 
   const url = paymentInfoStore.getMethodUrl(method.id, currency ?? undefined)
 
-  if (url) {
-    openUrlInNewTab(url)
+  if (!url) {
+    return false
   }
+
+  openUrlInNewTab(url)
+  return true
 }
 
-const runWorkflowForMethod = async (method: PaymentMethodWithCurrencies, currency: string | null) => {
+const runWorkflowForMethod = async (
+  method: PaymentMethodWithCurrencies,
+  currency: string | null,
+): Promise<boolean> => {
   switch (method.id) {
     case 'transfer':
-      await transferExperienceRef.value?.run()
-      break
+      return (await transferExperienceRef.value?.run()) ?? false
     case 'toss':
-      await tossExperienceRef.value?.run()
-      break
+      return (await tossExperienceRef.value?.run()) ?? false
     case 'kakao':
-      await kakaoExperienceRef.value?.run()
-      break
+      return (await kakaoExperienceRef.value?.run()) ?? false
     default:
-      await openMethodUrl(method, currency)
+      return await openMethodUrl(method, currency)
   }
 }
 
@@ -117,6 +125,125 @@ const onCurrencySelect = (currency: string) => {
 
 const onCloseCurrencySelector = () => {
   paymentStore.closeCurrencySelector()
+}
+
+const resolveRouteCandidate = (): RouteCandidate | null => {
+  const { pathname, search, hash } = window.location
+  const normalizedPathname = pathname.replace(/\/+$/, '') || '/'
+  const segments = normalizedPathname.split('/').filter(Boolean)
+
+  if (!segments.length) {
+    return null
+  }
+
+  const methodId = segments[segments.length - 1]
+  const baseSegments = segments.slice(0, -1)
+  const basePathname = baseSegments.length ? `/${baseSegments.join('/')}` : '/'
+
+  return {
+    methodId,
+    basePath: `${basePathname}${search}${hash}` || '/',
+  }
+}
+
+const pendingRoute = ref<RouteCandidate | null>(null)
+const routeState = ref<RouteCandidate | null>(null)
+const isHandlingRoute = ref(false)
+
+const restoreRoutePath = () => {
+  if (!routeState.value) {
+    return
+  }
+
+  const basePath = routeState.value.basePath || '/'
+  const current = `${window.location.pathname}${window.location.search}${window.location.hash}`
+
+  if (current !== basePath) {
+    window.history.replaceState(null, '', basePath)
+  } else {
+    window.history.replaceState(null, '', basePath)
+  }
+
+  pendingRoute.value = null
+  routeState.value = null
+}
+
+const tryHandlePendingRoute = async () => {
+  if (!pendingRoute.value || isHandlingRoute.value) {
+    return
+  }
+
+  const candidate = pendingRoute.value
+  const method = paymentStore.getMethodById(candidate.methodId)
+
+  if (!method) {
+    if (!areMethodsLoading.value && methods.value.length > 0) {
+      const isValidMethod = methods.value.some((entry) => entry.id === candidate.methodId)
+
+      if (!isValidMethod) {
+        pendingRoute.value = null
+      }
+    }
+
+    return
+  }
+
+  isHandlingRoute.value = true
+  routeState.value = candidate
+  pendingRoute.value = null
+
+  try {
+    const defaultCurrency = method.supportedCurrencies[0] ?? null
+    const succeeded = await runWorkflowForMethod(method, defaultCurrency)
+
+    if (!succeeded) {
+      restoreRoutePath()
+    }
+  } finally {
+    isHandlingRoute.value = false
+  }
+}
+
+const updateRouteFromLocation = () => {
+  const candidate = resolveRouteCandidate()
+
+  if (!candidate || candidate.methodId !== routeState.value?.methodId) {
+    routeState.value = null
+  }
+
+  pendingRoute.value = candidate
+  void tryHandlePendingRoute()
+}
+
+onMounted(() => {
+  updateRouteFromLocation()
+  window.addEventListener('popstate', updateRouteFromLocation)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('popstate', updateRouteFromLocation)
+})
+
+watch(
+  () => methods.value.length,
+  () => {
+    void tryHandlePendingRoute()
+  },
+)
+
+watch(
+  () => pendingRoute.value,
+  () => {
+    void tryHandlePendingRoute()
+  },
+)
+
+const onMethodExperienceClose = (methodId: string) => {
+  if (routeState.value?.methodId !== methodId) {
+    return
+  }
+
+  restoreRoutePath()
 }
 </script>
 
@@ -158,9 +285,9 @@ const onCloseCurrencySelector = () => {
       @select="onCurrencySelect"
       @close="onCloseCurrencySelector"
     />
-    <TransferExperience ref="transferExperienceRef" />
-    <TossExperience ref="tossExperienceRef" />
-    <KakaoExperience ref="kakaoExperienceRef" />
+    <TransferExperience ref="transferExperienceRef" @close="onMethodExperienceClose('transfer')" />
+    <TossExperience ref="tossExperienceRef" @close="onMethodExperienceClose('toss')" />
+    <KakaoExperience ref="kakaoExperienceRef" @close="onMethodExperienceClose('kakao')" />
     <LoadingOverlay
       :visible="isDeepLinkChecking"
       :message="i18nStore.t('status.loading.deepLink')"

--- a/frontend/src/payments/components/kakao/KakaoExperience.vue
+++ b/frontend/src/payments/components/kakao/KakaoExperience.vue
@@ -7,6 +7,7 @@ import { resolveDeepLink, launchDeepLink } from '@/payments/services/deepLinkSer
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
 const paymentInfoStore = usePaymentInfoStore()
+const emit = defineEmits<{ close: [] }>()
 
 const notMobileDialogRef = ref<InstanceType<typeof IsNotMobileDialog> | null>(null)
 const notInstalledDialogRef = ref<InstanceType<typeof IsNotInstalledDialog> | null>(null)
@@ -44,9 +45,13 @@ const run = async (): Promise<boolean> => {
 defineExpose({
   run,
 })
+
+const onDialogClose = () => {
+  emit('close')
+}
 </script>
 
 <template>
-  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" @close="onDialogClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" @close="onDialogClose" />
 </template>

--- a/frontend/src/payments/components/toss/TossExperience.vue
+++ b/frontend/src/payments/components/toss/TossExperience.vue
@@ -10,6 +10,7 @@ import { resolveDeepLink, launchDeepLink } from '@/payments/services/deepLinkSer
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
 const paymentInfoStore = usePaymentInfoStore()
+const emit = defineEmits<{ close: [] }>()
 
 const isInstructionVisible = ref(false)
 const tossInstructionCountdown = ref(0)
@@ -85,6 +86,7 @@ const run = async (): Promise<boolean> => {
 
 const onInstructionClose = () => {
   closeInstructionDialog()
+  emit('close')
 }
 
 const onInstructionLaunchNow = () => {
@@ -97,6 +99,10 @@ const onInstructionReopen = () => {
   }
 
   void runDeepLink(tossDeepLinkUrl.value)
+}
+
+const onDialogClose = () => {
+  emit('close')
 }
 
 defineExpose({
@@ -113,6 +119,6 @@ defineExpose({
     @launch-now="onInstructionLaunchNow"
     @reopen="onInstructionReopen"
   />
-  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" @close="onDialogClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" @close="onDialogClose" />
 </template>

--- a/frontend/src/payments/components/transfer/TransferExperience.vue
+++ b/frontend/src/payments/components/transfer/TransferExperience.vue
@@ -5,6 +5,7 @@ import TransferAccountsDialog from '@/payments/components/TransferAccountsDialog
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
 const paymentInfoStore = usePaymentInfoStore()
+const emit = defineEmits<{ close: [] }>()
 const isDialogVisible = ref(false)
 
 const transferAmount = computed(() => paymentInfoStore.transferInfo?.amount.krw ?? 0)
@@ -27,6 +28,7 @@ const closeDialog = () => {
 
 const onClose = () => {
   closeDialog()
+  emit('close')
 }
 
 defineExpose({


### PR DESCRIPTION
## Summary
- auto-run payment experiences when the current path ends with a supported method and return to the base path after dialogs close
- propagate close events from transfer, toss, and kakao experiences so routing logic can restore /roadshop when dialogs are dismissed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dffd542ee0832c88666fb03ae278ed