### PR TITLE
Enable router-driven payment dialogs

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "pinia": "^3.0.3",
         "primeicons": "^7.0.0",
         "qrcode": "^1.5.4",
-        "vue": "^3.5.18"
+        "vue": "^3.5.18",
+        "vue-router": "^4.4.5"
       },
       "devDependencies": {
         "@tsconfig/node22": "^22.0.2",
@@ -6146,6 +6147,27 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue-router/node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/vue-tsc": {
       "version": "3.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "pinia": "^3.0.3",
     "primeicons": "^7.0.0",
     "qrcode": "^1.5.4",
-    "vue": "^3.5.18"
+    "vue": "^3.5.18",
+    "vue-router": "^4.4.5"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.2",

--- a/frontend/src/app/App.vue
+++ b/frontend/src/app/App.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import Experience from '@/payments/components/Experience.vue'
+import { RouterView } from 'vue-router'
 </script>
 
 <template>
   <div class="flex min-h-screen flex-col bg-brand-highlight/40">
     <main class="mx-auto w-full max-w-5xl flex-1 px-6 py-12">
-      <Experience />
+      <RouterView />
     </main>
   </div>
 </template>

--- a/frontend/src/app/main.ts
+++ b/frontend/src/app/main.ts
@@ -3,6 +3,7 @@ import type { Pinia } from 'pinia'
 
 import App from '@/app/App.vue'
 import { createAppPinia } from '@/app/providers/createPinia'
+import { createAppRouter } from '@/app/providers/createRouter'
 import { useI18nStore } from '@/localization/store'
 
 const initializeLocalization = async (pinia: Pinia) => {
@@ -13,10 +14,13 @@ const initializeLocalization = async (pinia: Pinia) => {
 export const bootstrapApp = async () => {
   const app = createApp(App)
   const pinia = createAppPinia()
+  const router = createAppRouter()
 
   app.use(pinia)
+  app.use(router)
 
   await initializeLocalization(pinia)
+  await router.isReady()
 
   app.mount('#app')
 }

--- a/frontend/src/app/providers/createRouter.ts
+++ b/frontend/src/app/providers/createRouter.ts
@@ -1,0 +1,20 @@
+import { createRouter, createWebHistory } from 'vue-router'
+
+import Experience from '@/payments/components/Experience.vue'
+
+export const createAppRouter = () =>
+  createRouter({
+    history: createWebHistory(import.meta.env.BASE_URL),
+    routes: [
+      {
+        path: '/roadshop/:dialog?',
+        name: 'roadshop',
+        component: Experience,
+        alias: '/',
+      },
+      {
+        path: '/:pathMatch(.*)*',
+        redirect: '/roadshop',
+      },
+    ],
+  })

--- a/frontend/src/payments/components/kakao/KakaoExperience.vue
+++ b/frontend/src/payments/components/kakao/KakaoExperience.vue
@@ -7,6 +7,7 @@ import { resolveDeepLink, launchDeepLink } from '@/payments/services/deepLinkSer
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
 const paymentInfoStore = usePaymentInfoStore()
+const emit = defineEmits<{ close: [] }>()
 
 const notMobileDialogRef = ref<InstanceType<typeof IsNotMobileDialog> | null>(null)
 const notInstalledDialogRef = ref<InstanceType<typeof IsNotInstalledDialog> | null>(null)
@@ -44,9 +45,13 @@ const run = async (): Promise<boolean> => {
 defineExpose({
   run,
 })
+
+const onDialogClose = () => {
+  emit('close')
+}
 </script>
 
 <template>
-  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" @close="onDialogClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" @close="onDialogClose" />
 </template>

--- a/frontend/src/payments/components/toss/TossExperience.vue
+++ b/frontend/src/payments/components/toss/TossExperience.vue
@@ -10,6 +10,7 @@ import { resolveDeepLink, launchDeepLink } from '@/payments/services/deepLinkSer
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
 const paymentInfoStore = usePaymentInfoStore()
+const emit = defineEmits<{ close: [] }>()
 
 const isInstructionVisible = ref(false)
 const tossInstructionCountdown = ref(0)
@@ -85,6 +86,7 @@ const run = async (): Promise<boolean> => {
 
 const onInstructionClose = () => {
   closeInstructionDialog()
+  emit('close')
 }
 
 const onInstructionLaunchNow = () => {
@@ -97,6 +99,10 @@ const onInstructionReopen = () => {
   }
 
   void runDeepLink(tossDeepLinkUrl.value)
+}
+
+const onAuxiliaryDialogClose = () => {
+  emit('close')
 }
 
 defineExpose({
@@ -113,6 +119,6 @@ defineExpose({
     @launch-now="onInstructionLaunchNow"
     @reopen="onInstructionReopen"
   />
-  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" @close="onAuxiliaryDialogClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" @close="onAuxiliaryDialogClose" />
 </template>

--- a/frontend/src/payments/components/transfer/TransferExperience.vue
+++ b/frontend/src/payments/components/transfer/TransferExperience.vue
@@ -5,6 +5,7 @@ import TransferAccountsDialog from '@/payments/components/TransferAccountsDialog
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
 const paymentInfoStore = usePaymentInfoStore()
+const emit = defineEmits<{ close: [] }>()
 const isDialogVisible = ref(false)
 
 const transferAmount = computed(() => paymentInfoStore.transferInfo?.amount.krw ?? 0)
@@ -27,6 +28,7 @@ const closeDialog = () => {
 
 const onClose = () => {
   closeDialog()
+  emit('close')
 }
 
 defineExpose({


### PR DESCRIPTION
## Summary
- add a Vue Router instance with routes for /roadshop and method-specific dialog paths
- update the payment experience to watch the route, open the related dialogs, and return to /roadshop when they close
- forward dialog close events from individual experience components so routing state is reset correctly

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e001c7787c832ca7868b96969a6a33