### PR TITLE
Enable dialog routes for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build site
         run: npm run build
         env:
-          BASE_URL: ./
+          BASE_URL: /roadshop/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "pinia": "^3.0.3",
         "primeicons": "^7.0.0",
         "qrcode": "^1.5.4",
-        "vue": "^3.5.18"
+        "vue": "^3.5.18",
+        "vue-router": "^4.4.5"
       },
       "devDependencies": {
         "@tsconfig/node22": "^22.0.2",
@@ -6146,6 +6147,27 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue-router/node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/vue-tsc": {
       "version": "3.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "pinia": "^3.0.3",
     "primeicons": "^7.0.0",
     "qrcode": "^1.5.4",
-    "vue": "^3.5.18"
+    "vue": "^3.5.18",
+    "vue-router": "^4.4.5"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.2",

--- a/frontend/src/app/App.vue
+++ b/frontend/src/app/App.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import Experience from '@/payments/components/Experience.vue'
+import { RouterView } from 'vue-router'
 </script>
 
 <template>
   <div class="flex min-h-screen flex-col bg-brand-highlight/40">
     <main class="mx-auto w-full max-w-5xl flex-1 px-6 py-12">
-      <Experience />
+      <RouterView />
     </main>
   </div>
 </template>

--- a/frontend/src/app/main.ts
+++ b/frontend/src/app/main.ts
@@ -2,6 +2,7 @@ import { createApp } from 'vue'
 import type { Pinia } from 'pinia'
 
 import App from '@/app/App.vue'
+import router from '@/app/router'
 import { createAppPinia } from '@/app/providers/createPinia'
 import { useI18nStore } from '@/localization/store'
 
@@ -15,8 +16,10 @@ export const bootstrapApp = async () => {
   const pinia = createAppPinia()
 
   app.use(pinia)
+  app.use(router)
 
   await initializeLocalization(pinia)
+  await router.isReady()
 
   app.mount('#app')
 }

--- a/frontend/src/app/router/index.ts
+++ b/frontend/src/app/router/index.ts
@@ -1,0 +1,26 @@
+import { createRouter, createWebHistory } from 'vue-router'
+
+import Experience from '@/payments/components/Experience.vue'
+
+const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes: [
+    {
+      path: '/',
+      name: 'home',
+      component: Experience,
+    },
+    {
+      path: '/:method(kakao|toss|transfer)',
+      name: 'method',
+      component: Experience,
+    },
+    {
+      path: '/:pathMatch(.*)*',
+      redirect: '/',
+    },
+  ],
+  scrollBehavior: () => ({ top: 0 }),
+})
+
+export default router

--- a/frontend/src/payments/components/kakao/KakaoExperience.vue
+++ b/frontend/src/payments/components/kakao/KakaoExperience.vue
@@ -7,9 +7,17 @@ import { resolveDeepLink, launchDeepLink } from '@/payments/services/deepLinkSer
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
 const paymentInfoStore = usePaymentInfoStore()
+const emit = defineEmits<{ close: [] }>()
 
 const notMobileDialogRef = ref<InstanceType<typeof IsNotMobileDialog> | null>(null)
 const notInstalledDialogRef = ref<InstanceType<typeof IsNotInstalledDialog> | null>(null)
+let isClosingSilently = false
+
+const notifyClose = () => {
+  if (!isClosingSilently) {
+    emit('close')
+  }
+}
 
 const run = async (): Promise<boolean> => {
   const ready = await paymentInfoStore.ensureMethodInfo('kakao')
@@ -43,10 +51,19 @@ const run = async (): Promise<boolean> => {
 
 defineExpose({
   run,
+  close: () => {
+    isClosingSilently = true
+    try {
+      notMobileDialogRef.value?.close()
+      notInstalledDialogRef.value?.close()
+    } finally {
+      isClosingSilently = false
+    }
+  },
 })
 </script>
 
 <template>
-  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" @close="notifyClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" @close="notifyClose" />
 </template>

--- a/frontend/src/payments/components/toss/TossExperience.vue
+++ b/frontend/src/payments/components/toss/TossExperience.vue
@@ -10,6 +10,8 @@ import { resolveDeepLink, launchDeepLink } from '@/payments/services/deepLinkSer
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
 const paymentInfoStore = usePaymentInfoStore()
+const emit = defineEmits<{ close: [] }>()
+let isClosingSilently = false
 
 const isInstructionVisible = ref(false)
 const tossInstructionCountdown = ref(0)
@@ -85,6 +87,9 @@ const run = async (): Promise<boolean> => {
 
 const onInstructionClose = () => {
   closeInstructionDialog()
+  if (!isClosingSilently) {
+    emit('close')
+  }
 }
 
 const onInstructionLaunchNow = () => {
@@ -99,8 +104,32 @@ const onInstructionReopen = () => {
   void runDeepLink(tossDeepLinkUrl.value)
 }
 
+const onNotMobileClose = () => {
+  if (!isClosingSilently) {
+    emit('close')
+  }
+}
+
+const onNotInstalledClose = () => {
+  if (!isClosingSilently) {
+    emit('close')
+  }
+}
+
+const closeAllDialogs = () => {
+  isClosingSilently = true
+  try {
+    closeInstructionDialog()
+    notMobileDialogRef.value?.close()
+    notInstalledDialogRef.value?.close()
+  } finally {
+    isClosingSilently = false
+  }
+}
+
 defineExpose({
   run,
+  close: closeAllDialogs,
 })
 </script>
 
@@ -113,6 +142,6 @@ defineExpose({
     @launch-now="onInstructionLaunchNow"
     @reopen="onInstructionReopen"
   />
-  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" @close="onNotMobileClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" @close="onNotInstalledClose" />
 </template>

--- a/frontend/src/payments/components/transfer/TransferExperience.vue
+++ b/frontend/src/payments/components/transfer/TransferExperience.vue
@@ -5,6 +5,7 @@ import TransferAccountsDialog from '@/payments/components/TransferAccountsDialog
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
 const paymentInfoStore = usePaymentInfoStore()
+const emit = defineEmits<{ close: [] }>()
 const isDialogVisible = ref(false)
 
 const transferAmount = computed(() => paymentInfoStore.transferInfo?.amount.krw ?? 0)
@@ -27,10 +28,12 @@ const closeDialog = () => {
 
 const onClose = () => {
   closeDialog()
+  emit('close')
 }
 
 defineExpose({
   run: openDialog,
+  close: closeDialog,
 })
 </script>
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,7 +4,8 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
-const base = process.env.BASE_URL ?? './'
+const isProduction = process.env.NODE_ENV === 'production'
+const base = process.env.BASE_URL ?? (isProduction ? '/roadshop/' : '/')
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- add vue-router with a GitHub Pages base and mount the router in the application shell
- map method-specific routes to payment dialogs and return to the root path once they close
- expose close handlers on payment experiences and adjust GitHub Pages build configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e005092de8832cbe0e0e0a8153582f