### PR TITLE
Add router support for GitHub Pages dialog routes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "pinia": "^3.0.3",
         "primeicons": "^7.0.0",
         "qrcode": "^1.5.4",
-        "vue": "^3.5.18"
+        "vue": "^3.5.18",
+        "vue-router": "^4.4.5"
       },
       "devDependencies": {
         "@tsconfig/node22": "^22.0.2",
@@ -6146,6 +6147,27 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue-router/node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/vue-tsc": {
       "version": "3.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "pinia": "^3.0.3",
     "primeicons": "^7.0.0",
     "qrcode": "^1.5.4",
-    "vue": "^3.5.18"
+    "vue": "^3.5.18",
+    "vue-router": "^4.4.5"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.2",

--- a/frontend/src/app/App.vue
+++ b/frontend/src/app/App.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import Experience from '@/payments/components/Experience.vue'
+import { RouterView } from 'vue-router'
 </script>
 
 <template>
   <div class="flex min-h-screen flex-col bg-brand-highlight/40">
     <main class="mx-auto w-full max-w-5xl flex-1 px-6 py-12">
-      <Experience />
+      <RouterView />
     </main>
   </div>
 </template>

--- a/frontend/src/app/main.ts
+++ b/frontend/src/app/main.ts
@@ -3,6 +3,7 @@ import type { Pinia } from 'pinia'
 
 import App from '@/app/App.vue'
 import { createAppPinia } from '@/app/providers/createPinia'
+import { createAppRouter } from '@/app/providers/createRouter'
 import { useI18nStore } from '@/localization/store'
 
 const initializeLocalization = async (pinia: Pinia) => {
@@ -13,10 +14,14 @@ const initializeLocalization = async (pinia: Pinia) => {
 export const bootstrapApp = async () => {
   const app = createApp(App)
   const pinia = createAppPinia()
+  const router = createAppRouter()
 
   app.use(pinia)
+  app.use(router)
 
   await initializeLocalization(pinia)
+
+  await router.isReady()
 
   app.mount('#app')
 }

--- a/frontend/src/app/providers/createRouter.ts
+++ b/frontend/src/app/providers/createRouter.ts
@@ -1,0 +1,24 @@
+import { createRouter, createWebHistory } from 'vue-router'
+
+import Experience from '@/payments/components/Experience.vue'
+
+export const createAppRouter = () =>
+  createRouter({
+    history: createWebHistory(import.meta.env.BASE_URL),
+    routes: [
+      {
+        path: '/',
+        name: 'home',
+        component: Experience,
+      },
+      {
+        path: '/:method',
+        name: 'payment-method',
+        component: Experience,
+      },
+      {
+        path: '/:pathMatch(.*)*',
+        redirect: { name: 'home' },
+      },
+    ],
+  })

--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
+import { useRoute, useRouter } from 'vue-router'
 
 import LoadingOverlay from '@/shared/components/LoadingOverlay.vue'
 import CurrencySelectorDialog from '@/payments/components/CurrencySelectorDialog.vue'
@@ -23,6 +24,8 @@ defineOptions({
 const paymentStore = usePaymentStore()
 const paymentInfoStore = usePaymentInfoStore()
 const i18nStore = useI18nStore()
+const router = useRouter()
+const route = useRoute()
 
 const { methods, selectedMethod, selectedCurrency, isCurrencySelectorOpen, isLoading: areMethodsLoading, error: methodsError } =
   storeToRefs(paymentStore)
@@ -30,6 +33,13 @@ const { methods, selectedMethod, selectedCurrency, isCurrencySelectorOpen, isLoa
 const tossExperienceRef = ref<InstanceType<typeof TossExperience> | null>(null)
 const kakaoExperienceRef = ref<InstanceType<typeof KakaoExperience> | null>(null)
 const transferExperienceRef = ref<InstanceType<typeof TransferExperience> | null>(null)
+const methodFromRoute = computed(() => {
+  const { method } = route.params
+
+  return typeof method === 'string' ? method : null
+})
+const pendingRouteMethod = ref<string | null>(null)
+const triggeredRouteMethod = ref<string | null>(null)
 
 const categorizeMethod = (method: PaymentMethodWithCurrencies): PaymentCategory =>
   method.supportedCurrencies.some((currency) => currency !== 'KRW') ? 'GLOBAL' : 'KRW'
@@ -56,6 +66,15 @@ const selectedMethodName = computed(() =>
 )
 
 const selectedMethodCurrencies = computed(() => selectedMethod.value?.supportedCurrencies ?? [])
+
+const navigateHome = () => {
+  triggeredRouteMethod.value = pendingRouteMethod.value
+  paymentStore.resetSelection()
+
+  if (route.name !== 'home') {
+    void router.replace({ name: 'home' })
+  }
+}
 
 const openMethodUrl = async (method: PaymentMethodWithCurrencies, currency: string | null) => {
   const ready = await paymentInfoStore.ensureMethodInfo(method.id)
@@ -87,16 +106,75 @@ const runWorkflowForMethod = async (method: PaymentMethodWithCurrencies, currenc
   }
 }
 
-const onSelectMethod = (methodId: string) => {
-  paymentStore.selectMethod(methodId)
+const tryRunMethodFromRoute = async () => {
+  const methodId = pendingRouteMethod.value
 
-  const method = paymentStore.getMethodById(methodId)
-
-  if (!method || isCurrencySelectorOpen.value) {
+  if (!methodId || triggeredRouteMethod.value === methodId) {
     return
   }
 
-  void runWorkflowForMethod(method, selectedCurrency.value)
+  const method = paymentStore.getMethodById(methodId)
+
+  if (!method) {
+    if (!areMethodsLoading.value) {
+      triggeredRouteMethod.value = methodId
+      navigateHome()
+    }
+
+    return
+  }
+
+  triggeredRouteMethod.value = methodId
+  paymentStore.selectMethod(methodId)
+
+  if (!isCurrencySelectorOpen.value) {
+    await runWorkflowForMethod(method, selectedCurrency.value)
+  }
+}
+
+watch(
+  methodFromRoute,
+  (method) => {
+    pendingRouteMethod.value = method
+
+    if (!method) {
+      triggeredRouteMethod.value = null
+      paymentStore.resetSelection()
+      return
+    }
+
+    if (triggeredRouteMethod.value !== method) {
+      triggeredRouteMethod.value = null
+    }
+
+    void tryRunMethodFromRoute()
+  },
+  { immediate: true },
+)
+
+watch(
+  () => methods.value.length,
+  () => {
+    void tryRunMethodFromRoute()
+  },
+)
+
+watch(areMethodsLoading, (loading) => {
+  if (!loading) {
+    void tryRunMethodFromRoute()
+  }
+})
+
+const onSelectMethod = (methodId: string) => {
+  if (methodFromRoute.value !== methodId) {
+    void router.replace({ name: 'payment-method', params: { method: methodId } })
+    return
+  }
+
+  pendingRouteMethod.value = methodId
+  triggeredRouteMethod.value = null
+
+  void tryRunMethodFromRoute()
 }
 
 const onCurrencySelect = (currency: string) => {
@@ -116,7 +194,11 @@ const onCurrencySelect = (currency: string) => {
 }
 
 const onCloseCurrencySelector = () => {
-  paymentStore.closeCurrencySelector()
+  navigateHome()
+}
+
+const onDialogClose = () => {
+  navigateHome()
 }
 </script>
 
@@ -158,9 +240,9 @@ const onCloseCurrencySelector = () => {
       @select="onCurrencySelect"
       @close="onCloseCurrencySelector"
     />
-    <TransferExperience ref="transferExperienceRef" />
-    <TossExperience ref="tossExperienceRef" />
-    <KakaoExperience ref="kakaoExperienceRef" />
+    <TransferExperience ref="transferExperienceRef" @close="onDialogClose" />
+    <TossExperience ref="tossExperienceRef" @close="onDialogClose" />
+    <KakaoExperience ref="kakaoExperienceRef" @close="onDialogClose" />
     <LoadingOverlay
       :visible="isDeepLinkChecking"
       :message="i18nStore.t('status.loading.deepLink')"

--- a/frontend/src/payments/components/kakao/KakaoExperience.vue
+++ b/frontend/src/payments/components/kakao/KakaoExperience.vue
@@ -6,6 +6,8 @@ import IsNotMobileDialog from '@/payments/components/IsNotMobileDialog.vue'
 import { resolveDeepLink, launchDeepLink } from '@/payments/services/deepLinkService'
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
+const emit = defineEmits<{ close: [] }>()
+
 const paymentInfoStore = usePaymentInfoStore()
 
 const notMobileDialogRef = ref<InstanceType<typeof IsNotMobileDialog> | null>(null)
@@ -41,12 +43,20 @@ const run = async (): Promise<boolean> => {
   }
 }
 
+const onNotMobileClose = () => {
+  emit('close')
+}
+
+const onNotInstalledClose = () => {
+  emit('close')
+}
+
 defineExpose({
   run,
 })
 </script>
 
 <template>
-  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" @close="onNotMobileClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" @close="onNotInstalledClose" />
 </template>

--- a/frontend/src/payments/components/toss/TossExperience.vue
+++ b/frontend/src/payments/components/toss/TossExperience.vue
@@ -9,6 +9,8 @@ import { copyTransferInfo } from '@/payments/utils/copyTransferInfo'
 import { resolveDeepLink, launchDeepLink } from '@/payments/services/deepLinkService'
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
+const emit = defineEmits<{ close: [] }>()
+
 const paymentInfoStore = usePaymentInfoStore()
 
 const isInstructionVisible = ref(false)
@@ -85,6 +87,7 @@ const run = async (): Promise<boolean> => {
 
 const onInstructionClose = () => {
   closeInstructionDialog()
+  emit('close')
 }
 
 const onInstructionLaunchNow = () => {
@@ -97,6 +100,14 @@ const onInstructionReopen = () => {
   }
 
   void runDeepLink(tossDeepLinkUrl.value)
+}
+
+const onNotMobileClose = () => {
+  emit('close')
+}
+
+const onNotInstalledClose = () => {
+  emit('close')
 }
 
 defineExpose({
@@ -113,6 +124,6 @@ defineExpose({
     @launch-now="onInstructionLaunchNow"
     @reopen="onInstructionReopen"
   />
-  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" @close="onNotMobileClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" @close="onNotInstalledClose" />
 </template>

--- a/frontend/src/payments/components/transfer/TransferExperience.vue
+++ b/frontend/src/payments/components/transfer/TransferExperience.vue
@@ -4,6 +4,8 @@ import { computed, ref } from 'vue'
 import TransferAccountsDialog from '@/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue'
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
+const emit = defineEmits<{ close: [] }>()
+
 const paymentInfoStore = usePaymentInfoStore()
 const isDialogVisible = ref(false)
 
@@ -27,6 +29,7 @@ const closeDialog = () => {
 
 const onClose = () => {
   closeDialog()
+  emit('close')
 }
 
 defineExpose({

--- a/frontend/src/payments/stores/payment.store.ts
+++ b/frontend/src/payments/stores/payment.store.ts
@@ -101,6 +101,12 @@ export const usePaymentStore = defineStore('payment', () => {
     isCurrencySelectorOpen.value = false
   }
 
+  const resetSelection = () => {
+    selectedMethodId.value = null
+    selectedCurrency.value = null
+    isCurrencySelectorOpen.value = false
+  }
+
   return {
     methods,
     isLoading,
@@ -112,6 +118,7 @@ export const usePaymentStore = defineStore('payment', () => {
     selectMethod,
     chooseCurrency,
     closeCurrencySelector,
+    resetSelection,
     getMethodById: findMethodById,
     getSupportedCurrencies: (methodId: string) =>
       findMethodById(methodId)?.supportedCurrencies ?? [],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,19 +4,21 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
-const base = process.env.BASE_URL ?? './'
-
 // https://vite.dev/config/
-export default defineConfig({
-  base,
-  plugins: [
-    vue(),
-    vueDevTools(),
-  ],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-      '@icons': fileURLToPath(new URL('./src/assets/icons', import.meta.url)),
+export default defineConfig(({ mode }) => {
+  const base = process.env.BASE_URL ?? (mode === 'production' ? '/roadshop/' : '/')
+
+  return {
+    base,
+    plugins: [
+      vue(),
+      vueDevTools(),
+    ],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+        '@icons': fileURLToPath(new URL('./src/assets/icons', import.meta.url)),
+      },
     },
-  },
+  }
 })


### PR DESCRIPTION
## Summary
- configure Vue Router with a GitHub Pages base and new payment routes
- synchronize the payment experience with route parameters to open and close dialogs via the URL
- propagate close events from dialogs so navigation returns to the main `/roadshop` view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e005092de8832cbe0e0e0a8153582f