### PR TITLE
Configure router support for GitHub Pages deep links

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "pinia": "^3.0.3",
         "primeicons": "^7.0.0",
         "qrcode": "^1.5.4",
-        "vue": "^3.5.18"
+        "vue": "^3.5.18",
+        "vue-router": "^4.4.5"
       },
       "devDependencies": {
         "@tsconfig/node22": "^22.0.2",
@@ -6146,6 +6147,27 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue-router/node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/vue-tsc": {
       "version": "3.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "pinia": "^3.0.3",
+    "vue-router": "^4.4.5",
     "primeicons": "^7.0.0",
     "qrcode": "^1.5.4",
     "vue": "^3.5.18"

--- a/frontend/src/app/App.vue
+++ b/frontend/src/app/App.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import Experience from '@/payments/components/Experience.vue'
+import { RouterView } from 'vue-router'
 </script>
 
 <template>
   <div class="flex min-h-screen flex-col bg-brand-highlight/40">
     <main class="mx-auto w-full max-w-5xl flex-1 px-6 py-12">
-      <Experience />
+      <RouterView />
     </main>
   </div>
 </template>

--- a/frontend/src/app/main.ts
+++ b/frontend/src/app/main.ts
@@ -3,6 +3,7 @@ import type { Pinia } from 'pinia'
 
 import App from '@/app/App.vue'
 import { createAppPinia } from '@/app/providers/createPinia'
+import { createAppRouter } from '@/app/providers/createRouter'
 import { useI18nStore } from '@/localization/store'
 
 const initializeLocalization = async (pinia: Pinia) => {
@@ -13,10 +14,14 @@ const initializeLocalization = async (pinia: Pinia) => {
 export const bootstrapApp = async () => {
   const app = createApp(App)
   const pinia = createAppPinia()
+  const router = createAppRouter()
 
   app.use(pinia)
+  app.use(router)
 
   await initializeLocalization(pinia)
+
+  await router.isReady()
 
   app.mount('#app')
 }

--- a/frontend/src/app/providers/createRouter.ts
+++ b/frontend/src/app/providers/createRouter.ts
@@ -1,0 +1,26 @@
+import { createRouter, createWebHistory } from 'vue-router'
+
+import Experience from '@/payments/components/Experience.vue'
+
+const routes = [
+  {
+    path: '/',
+    name: 'home',
+    component: Experience,
+  },
+  {
+    path: '/:method(kakao|toss|transfer)',
+    name: 'payment-method',
+    component: Experience,
+  },
+  {
+    path: '/:pathMatch(.*)*',
+    redirect: '/',
+  },
+]
+
+export const createAppRouter = () =>
+  createRouter({
+    history: createWebHistory(import.meta.env.BASE_URL),
+    routes,
+  })

--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
+import { useRoute, useRouter } from 'vue-router'
 
 import LoadingOverlay from '@/shared/components/LoadingOverlay.vue'
 import CurrencySelectorDialog from '@/payments/components/CurrencySelectorDialog.vue'
@@ -23,6 +24,8 @@ defineOptions({
 const paymentStore = usePaymentStore()
 const paymentInfoStore = usePaymentInfoStore()
 const i18nStore = useI18nStore()
+const router = useRouter()
+const route = useRoute()
 
 const { methods, selectedMethod, selectedCurrency, isCurrencySelectorOpen, isLoading: areMethodsLoading, error: methodsError } =
   storeToRefs(paymentStore)
@@ -118,6 +121,62 @@ const onCurrencySelect = (currency: string) => {
 const onCloseCurrencySelector = () => {
   paymentStore.closeCurrencySelector()
 }
+
+const routeMethod = computed(() => {
+  const param = route.params.method
+  return typeof param === 'string' ? param : null
+})
+
+const navigateHome = async () => {
+  if (route.name === 'home') {
+    return
+  }
+
+  await router.replace({ name: 'home' })
+}
+
+const handleRouteMethod = async (methodId: string) => {
+  if (areMethodsLoading.value) {
+    return
+  }
+
+  const method = paymentStore.getMethodById(methodId)
+
+  if (!method) {
+    await navigateHome()
+    return
+  }
+
+  paymentStore.selectMethod(methodId)
+
+  if (!selectedCurrency.value) {
+    const defaultCurrency = method.supportedCurrencies[0] ?? null
+
+    if (defaultCurrency) {
+      paymentStore.chooseCurrency(defaultCurrency)
+    }
+  }
+
+  const currency = selectedCurrency.value ?? method.supportedCurrencies[0] ?? null
+
+  await runWorkflowForMethod(method, currency)
+}
+
+watch(
+  () => [routeMethod.value, areMethodsLoading.value] as const,
+  ([methodId, loading]) => {
+    if (!methodId || loading) {
+      return
+    }
+
+    void handleRouteMethod(methodId)
+  },
+  { immediate: true },
+)
+
+const onExperienceClose = async () => {
+  await navigateHome()
+}
 </script>
 
 <template>
@@ -158,9 +217,9 @@ const onCloseCurrencySelector = () => {
       @select="onCurrencySelect"
       @close="onCloseCurrencySelector"
     />
-    <TransferExperience ref="transferExperienceRef" />
-    <TossExperience ref="tossExperienceRef" />
-    <KakaoExperience ref="kakaoExperienceRef" />
+    <TransferExperience ref="transferExperienceRef" @close="onExperienceClose" />
+    <TossExperience ref="tossExperienceRef" @close="onExperienceClose" />
+    <KakaoExperience ref="kakaoExperienceRef" @close="onExperienceClose" />
     <LoadingOverlay
       :visible="isDeepLinkChecking"
       :message="i18nStore.t('status.loading.deepLink')"

--- a/frontend/src/payments/components/kakao/KakaoExperience.vue
+++ b/frontend/src/payments/components/kakao/KakaoExperience.vue
@@ -7,6 +7,7 @@ import { resolveDeepLink, launchDeepLink } from '@/payments/services/deepLinkSer
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
 const paymentInfoStore = usePaymentInfoStore()
+const emit = defineEmits<{ close: [] }>()
 
 const notMobileDialogRef = ref<InstanceType<typeof IsNotMobileDialog> | null>(null)
 const notInstalledDialogRef = ref<InstanceType<typeof IsNotInstalledDialog> | null>(null)
@@ -44,9 +45,13 @@ const run = async (): Promise<boolean> => {
 defineExpose({
   run,
 })
+
+const onDialogClose = () => {
+  emit('close')
+}
 </script>
 
 <template>
-  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" @close="onDialogClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" @close="onDialogClose" />
 </template>

--- a/frontend/src/payments/components/toss/TossExperience.vue
+++ b/frontend/src/payments/components/toss/TossExperience.vue
@@ -10,6 +10,7 @@ import { resolveDeepLink, launchDeepLink } from '@/payments/services/deepLinkSer
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
 const paymentInfoStore = usePaymentInfoStore()
+const emit = defineEmits<{ close: [] }>()
 
 const isInstructionVisible = ref(false)
 const tossInstructionCountdown = ref(0)
@@ -85,6 +86,7 @@ const run = async (): Promise<boolean> => {
 
 const onInstructionClose = () => {
   closeInstructionDialog()
+  emit('close')
 }
 
 const onInstructionLaunchNow = () => {
@@ -102,6 +104,14 @@ const onInstructionReopen = () => {
 defineExpose({
   run,
 })
+
+const onNotMobileDialogClose = () => {
+  emit('close')
+}
+
+const onNotInstalledDialogClose = () => {
+  emit('close')
+}
 </script>
 
 <template>
@@ -113,6 +123,6 @@ defineExpose({
     @launch-now="onInstructionLaunchNow"
     @reopen="onInstructionReopen"
   />
-  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" @close="onNotMobileDialogClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" @close="onNotInstalledDialogClose" />
 </template>

--- a/frontend/src/payments/components/transfer/TransferExperience.vue
+++ b/frontend/src/payments/components/transfer/TransferExperience.vue
@@ -5,6 +5,7 @@ import TransferAccountsDialog from '@/payments/components/TransferAccountsDialog
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
 const paymentInfoStore = usePaymentInfoStore()
+const emit = defineEmits<{ close: [] }>()
 const isDialogVisible = ref(false)
 
 const transferAmount = computed(() => paymentInfoStore.transferInfo?.amount.krw ?? 0)
@@ -27,6 +28,7 @@ const closeDialog = () => {
 
 const onClose = () => {
   closeDialog()
+  emit('close')
 }
 
 defineExpose({

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,7 +4,8 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
-const base = process.env.BASE_URL ?? './'
+const isProduction = process.env.NODE_ENV === 'production'
+const base = process.env.BASE_URL ?? (isProduction ? '/roadshop/' : '/')
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- add Vue Router to the app and configure the Vite base so GitHub Pages serves from `/roadshop/`
- render the payment experience through the router and auto-run dialogs when visiting method-specific paths
- propagate close events from dialogs so closing them navigates back to the home route

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e00adb20a0832cb0b3d6cfa677f096