### PR TITLE
Add Vue Router configuration for GitHub Pages dialogs

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "pinia": "^3.0.3",
         "primeicons": "^7.0.0",
         "qrcode": "^1.5.4",
-        "vue": "^3.5.18"
+        "vue": "^3.5.18",
+        "vue-router": "^4.5.1"
       },
       "devDependencies": {
         "@tsconfig/node22": "^22.0.2",
@@ -6146,6 +6147,27 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue-router/node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/vue-tsc": {
       "version": "3.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "pinia": "^3.0.3",
     "primeicons": "^7.0.0",
     "qrcode": "^1.5.4",
-    "vue": "^3.5.18"
+    "vue": "^3.5.18",
+    "vue-router": "^4.5.1"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.2",

--- a/frontend/src/app/App.vue
+++ b/frontend/src/app/App.vue
@@ -1,11 +1,7 @@
-<script setup lang="ts">
-import Experience from '@/payments/components/Experience.vue'
-</script>
-
 <template>
   <div class="flex min-h-screen flex-col bg-brand-highlight/40">
     <main class="mx-auto w-full max-w-5xl flex-1 px-6 py-12">
-      <Experience />
+      <RouterView />
     </main>
   </div>
 </template>

--- a/frontend/src/app/main.ts
+++ b/frontend/src/app/main.ts
@@ -3,6 +3,7 @@ import type { Pinia } from 'pinia'
 
 import App from '@/app/App.vue'
 import { createAppPinia } from '@/app/providers/createPinia'
+import { createAppRouter } from '@/app/providers/createRouter'
 import { useI18nStore } from '@/localization/store'
 
 const initializeLocalization = async (pinia: Pinia) => {
@@ -13,10 +14,14 @@ const initializeLocalization = async (pinia: Pinia) => {
 export const bootstrapApp = async () => {
   const app = createApp(App)
   const pinia = createAppPinia()
+  const router = createAppRouter()
 
   app.use(pinia)
+  app.use(router)
 
   await initializeLocalization(pinia)
+
+  await router.isReady()
 
   app.mount('#app')
 }

--- a/frontend/src/app/providers/createRouter.ts
+++ b/frontend/src/app/providers/createRouter.ts
@@ -1,0 +1,14 @@
+import { createRouter, createWebHistory } from 'vue-router'
+
+export const createAppRouter = () =>
+  createRouter({
+    history: createWebHistory(import.meta.env.BASE_URL),
+    routes: [
+      {
+        path: '/:dialog(kakao|toss|transfer)?',
+        name: 'experience',
+        component: () => import('@/app/views/ExperienceView.vue'),
+      },
+    ],
+    scrollBehavior: () => ({ top: 0 }),
+  })

--- a/frontend/src/app/views/ExperienceView.vue
+++ b/frontend/src/app/views/ExperienceView.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import Experience from '@/payments/components/Experience.vue'
+</script>
+
+<template>
+  <Experience />
+</template>

--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
+import { useRoute, useRouter } from 'vue-router'
 
 import LoadingOverlay from '@/shared/components/LoadingOverlay.vue'
 import CurrencySelectorDialog from '@/payments/components/CurrencySelectorDialog.vue'
@@ -20,9 +21,13 @@ defineOptions({
   name: 'PaymentExperience',
 })
 
+type DialogRoute = 'kakao' | 'toss' | 'transfer'
+
 const paymentStore = usePaymentStore()
 const paymentInfoStore = usePaymentInfoStore()
 const i18nStore = useI18nStore()
+const router = useRouter()
+const route = useRoute()
 
 const { methods, selectedMethod, selectedCurrency, isCurrencySelectorOpen, isLoading: areMethodsLoading, error: methodsError } =
   storeToRefs(paymentStore)
@@ -30,6 +35,86 @@ const { methods, selectedMethod, selectedCurrency, isCurrencySelectorOpen, isLoa
 const tossExperienceRef = ref<InstanceType<typeof TossExperience> | null>(null)
 const kakaoExperienceRef = ref<InstanceType<typeof KakaoExperience> | null>(null)
 const transferExperienceRef = ref<InstanceType<typeof TransferExperience> | null>(null)
+
+const requestedDialog = computed<DialogRoute | null>(() => {
+  const dialogParam = route.params.dialog
+
+  if (Array.isArray(dialogParam)) {
+    return dialogParam[0] as DialogRoute
+  }
+
+  return (dialogParam as DialogRoute | undefined) ?? null
+})
+
+let lastOpenedDialog: DialogRoute | null = null
+
+const selectMethodForDialog = (dialog: DialogRoute) => {
+  if (paymentStore.selectedMethodId !== dialog) {
+    paymentStore.selectMethod(dialog)
+  }
+}
+
+const openDialogForRoute = async (dialog: DialogRoute | null): Promise<boolean> => {
+  if (!dialog) {
+    return false
+  }
+
+  selectMethodForDialog(dialog)
+
+  switch (dialog) {
+    case 'kakao':
+      return (await kakaoExperienceRef.value?.openNotMobileDialog()) ?? false
+    case 'toss':
+      return (await tossExperienceRef.value?.openInstructionDialog()) ?? false
+    case 'transfer':
+      return (await transferExperienceRef.value?.openDialog()) ?? false
+    default:
+      return false
+  }
+}
+
+const navigateHome = () => {
+  lastOpenedDialog = null
+
+  if (requestedDialog.value) {
+    void router.push('/')
+  }
+}
+
+watch(
+  requestedDialog,
+  async (dialog) => {
+    if (!dialog) {
+      lastOpenedDialog = null
+      return
+    }
+
+    if (lastOpenedDialog === dialog) {
+      return
+    }
+
+    const opened = await openDialogForRoute(dialog)
+
+    if (opened) {
+      lastOpenedDialog = dialog
+    }
+  },
+  { immediate: true },
+)
+
+watch(
+  methods,
+  () => {
+    const dialog = requestedDialog.value
+
+    if (!dialog) {
+      return
+    }
+
+    selectMethodForDialog(dialog)
+  },
+  { immediate: false },
+)
 
 const categorizeMethod = (method: PaymentMethodWithCurrencies): PaymentCategory =>
   method.supportedCurrencies.some((currency) => currency !== 'KRW') ? 'GLOBAL' : 'KRW'
@@ -158,9 +243,9 @@ const onCloseCurrencySelector = () => {
       @select="onCurrencySelect"
       @close="onCloseCurrencySelector"
     />
-    <TransferExperience ref="transferExperienceRef" />
-    <TossExperience ref="tossExperienceRef" />
-    <KakaoExperience ref="kakaoExperienceRef" />
+    <TransferExperience ref="transferExperienceRef" @close="navigateHome" />
+    <TossExperience ref="tossExperienceRef" @close="navigateHome" />
+    <KakaoExperience ref="kakaoExperienceRef" @close="navigateHome" />
     <LoadingOverlay
       :visible="isDeepLinkChecking"
       :message="i18nStore.t('status.loading.deepLink')"

--- a/frontend/src/payments/components/kakao/KakaoExperience.vue
+++ b/frontend/src/payments/components/kakao/KakaoExperience.vue
@@ -6,13 +6,41 @@ import IsNotMobileDialog from '@/payments/components/IsNotMobileDialog.vue'
 import { resolveDeepLink, launchDeepLink } from '@/payments/services/deepLinkService'
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
+const emit = defineEmits<{ (event: 'close'): void }>()
+
 const paymentInfoStore = usePaymentInfoStore()
 
 const notMobileDialogRef = ref<InstanceType<typeof IsNotMobileDialog> | null>(null)
 const notInstalledDialogRef = ref<InstanceType<typeof IsNotInstalledDialog> | null>(null)
 
+const ensureKakaoInfo = async () => paymentInfoStore.ensureMethodInfo('kakao')
+
+const openNotMobileDialog = async (): Promise<boolean> => {
+  const ready = await ensureKakaoInfo()
+
+  if (!ready) {
+    return false
+  }
+
+  notMobileDialogRef.value?.open()
+
+  return true
+}
+
+const openNotInstalledDialog = async (): Promise<boolean> => {
+  const ready = await ensureKakaoInfo()
+
+  if (!ready) {
+    return false
+  }
+
+  notInstalledDialogRef.value?.open()
+
+  return true
+}
+
 const run = async (): Promise<boolean> => {
-  const ready = await paymentInfoStore.ensureMethodInfo('kakao')
+  const ready = await ensureKakaoInfo()
 
   if (!ready) {
     return false
@@ -41,12 +69,18 @@ const run = async (): Promise<boolean> => {
   }
 }
 
+const onDialogClose = () => {
+  emit('close')
+}
+
 defineExpose({
   run,
+  openNotMobileDialog,
+  openNotInstalledDialog,
 })
 </script>
 
 <template>
-  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" @close="onDialogClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" @close="onDialogClose" />
 </template>

--- a/frontend/src/payments/components/toss/TossExperience.vue
+++ b/frontend/src/payments/components/toss/TossExperience.vue
@@ -9,6 +9,8 @@ import { copyTransferInfo } from '@/payments/utils/copyTransferInfo'
 import { resolveDeepLink, launchDeepLink } from '@/payments/services/deepLinkService'
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
+const emit = defineEmits<{ (event: 'close'): void }>()
+
 const paymentInfoStore = usePaymentInfoStore()
 
 const isInstructionVisible = ref(false)
@@ -33,11 +35,26 @@ const closeInstructionDialog = () => {
   isInstructionVisible.value = false
   tossInstructionCountdown.value = 0
   tossDeepLinkUrl.value = null
+  emit('close')
 }
 
 const showInstructionDialog = async (seconds: number): Promise<boolean> => {
   isInstructionVisible.value = true
   return countdownManager.start(seconds)
+}
+
+const openInstructionDialog = async (): Promise<boolean> => {
+  const ready = await paymentInfoStore.ensureMethodInfo('toss')
+
+  if (!ready) {
+    return false
+  }
+
+  countdownManager.reset()
+  tossInstructionCountdown.value = 0
+  isInstructionVisible.value = true
+
+  return true
 }
 
 const runDeepLink = async (deepLink: string) => {
@@ -99,8 +116,13 @@ const onInstructionReopen = () => {
   void runDeepLink(tossDeepLinkUrl.value)
 }
 
+const onFallbackDialogClose = () => {
+  emit('close')
+}
+
 defineExpose({
   run,
+  openInstructionDialog,
 })
 </script>
 
@@ -113,6 +135,6 @@ defineExpose({
     @launch-now="onInstructionLaunchNow"
     @reopen="onInstructionReopen"
   />
-  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" @close="onFallbackDialogClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" @close="onFallbackDialogClose" />
 </template>

--- a/frontend/src/payments/components/transfer/TransferExperience.vue
+++ b/frontend/src/payments/components/transfer/TransferExperience.vue
@@ -4,6 +4,8 @@ import { computed, ref } from 'vue'
 import TransferAccountsDialog from '@/payments/components/TransferAccountsDialog/TransferAccountsDialog.vue'
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
+const emit = defineEmits<{ (event: 'close'): void }>()
+
 const paymentInfoStore = usePaymentInfoStore()
 const isDialogVisible = ref(false)
 
@@ -23,6 +25,7 @@ const openDialog = async (): Promise<boolean> => {
 
 const closeDialog = () => {
   isDialogVisible.value = false
+  emit('close')
 }
 
 const onClose = () => {
@@ -31,6 +34,8 @@ const onClose = () => {
 
 defineExpose({
   run: openDialog,
+  openDialog,
+  closeDialog,
 })
 </script>
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
-const base = process.env.BASE_URL ?? './'
+const base = process.env.BASE_URL ?? '/roadshop/'
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- configure a shared Vue Router with the `/roadshop/` base and update the app shell to render views through it
- map dialog-friendly routes to the payment experience and automatically open/close the relevant dialogs via emitted events
- expose helpers on individual payment experiences so deep-link dialogs can be triggered directly from routing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e00adb20a0832cb0b3d6cfa677f096