### PR TITLE
Consume backend-provided deep link URLs

### DIFF
--- a/backend/response/method-kakao.json
+++ b/backend/response/method-kakao.json
@@ -5,6 +5,7 @@
     "amount": {
       "krw": 10000
     },
-    "personalCode": "000024398434938"
+    "personalCode": "000024398434938",
+    "deepLink": "kakaotalk://kakaopay/money/to/qr?qr_code=281006011000024398434938138800000"
   }
 }

--- a/backend/response/method-toss.json
+++ b/backend/response/method-toss.json
@@ -9,6 +9,7 @@
       "bank": "KB국민",
       "number": "93800200352361",
       "holder": "강일준"
-    }
+    },
+    "deepLink": "supertoss://send?amount=10000&bank=KB%EA%B5%AD%EB%AF%BC&accountNo=93800200352361&origin=qr"
   }
 }

--- a/backend/response/payment-methods.json
+++ b/backend/response/payment-methods.json
@@ -6,13 +6,11 @@
     },
     {
       "id": "toss",
-      "supportedCurrencies": ["KRW"],
-      "deepLinkProvider": "toss"
+      "supportedCurrencies": ["KRW"]
     },
     {
       "id": "kakao",
-      "supportedCurrencies": ["KRW"],
-      "deepLinkProvider": "kakao"
+      "supportedCurrencies": ["KRW"]
     },
     {
       "id": "alipay",

--- a/frontend/src/payments/components/IsNotMobileDialog.vue
+++ b/frontend/src/payments/components/IsNotMobileDialog.vue
@@ -6,11 +6,12 @@ import QrCodeDisplay from '@/shared/components/QrCodeDisplay.vue'
 import { useI18nStore } from '@/localization/store'
 import { usePaymentStore } from '@/payments/stores/payment.store'
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
-import { resolveDeepLink } from '@/payments/services/deepLinkService'
-import type { DeepLinkProvider, PaymentIcon } from '@/payments/types'
+import type { PaymentIcon } from '@/payments/types'
+
+type DeepLinkCapableMethod = 'toss' | 'kakao'
 
 interface Props {
-  method: DeepLinkProvider
+  method: DeepLinkCapableMethod
 }
 
 const props = defineProps<Props>()
@@ -24,8 +25,7 @@ const paymentInfoStore = usePaymentInfoStore()
 const isVisible = ref(false)
 const qrValue = computed(() => {
   try {
-    const info = paymentInfoStore.getDeepLinkInfo(props.method)
-    return resolveDeepLink(props.method, info)
+    return paymentInfoStore.getMethodDeepLink(props.method)
   } catch (error) {
     console.error(error)
     return null

--- a/frontend/src/payments/components/toss/TossExperience.vue
+++ b/frontend/src/payments/components/toss/TossExperience.vue
@@ -6,7 +6,7 @@ import IsNotMobileDialog from '@/payments/components/IsNotMobileDialog.vue'
 import TossInstructionDialog from '@/payments/components/TossInstructionDialog.vue'
 import { createCountdownManager } from '@/payments/stores/utils/createCountdownManager'
 import { copyTransferInfo } from '@/payments/utils/copyTransferInfo'
-import { resolveDeepLink, launchDeepLink } from '@/payments/services/deepLinkService'
+import { launchDeepLink } from '@/payments/services/deepLinkService'
 import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
 const paymentInfoStore = usePaymentInfoStore()
@@ -64,8 +64,14 @@ const run = async (): Promise<boolean> => {
     return false
   }
 
+  const deepLink = info.deepLink
+
+  if (!deepLink) {
+    console.error('Missing toss deep link in payload')
+    return false
+  }
+
   try {
-    const deepLink = resolveDeepLink('toss', info)
     tossDeepLinkUrl.value = deepLink
 
     await copyTransferInfo(info.account, info.amount.krw)

--- a/frontend/src/payments/services/deepLinkService.ts
+++ b/frontend/src/payments/services/deepLinkService.ts
@@ -1,54 +1,6 @@
 import { ref } from 'vue'
 
-import type { DeepLinkProvider } from '@/payments/types'
-import type { KakaoPaymentInfo, TossPaymentInfo } from '@/payments/services/paymentInfoService'
 import { isMobileDevice } from '@/shared/utils/device'
-
-export const createTossDeepLink = (info: TossPaymentInfo): string => {
-  const params = new URLSearchParams({
-    amount: info.amount.krw.toString(),
-    bank: info.account.bank,
-    accountNo: info.account.number,
-    origin: 'qr',
-  })
-
-  return `supertoss://send?${params.toString()}`
-}
-
-export const createKakaoDeepLink = (info: KakaoPaymentInfo): string => {
-  const amount = info.amount.krw
-  const personalCode = info.personalCode
-
-  const hexAmount = Math.round(amount * 8).toString(16).toUpperCase()
-
-  return `kakaotalk://kakaopay/money/to/qr?qr_code=281006011${personalCode}${hexAmount}0000`
-}
-
-const isKakaoInfo = (info: TossPaymentInfo | KakaoPaymentInfo): info is KakaoPaymentInfo =>
-  'personalCode' in info
-
-export const resolveDeepLink = (
-  provider: DeepLinkProvider,
-  info: TossPaymentInfo | KakaoPaymentInfo | null,
-): string => {
-  if (!info) {
-    throw new Error(`Missing payment info for provider: ${provider}`)
-  }
-
-  if (provider === 'toss') {
-    if (isKakaoInfo(info)) {
-      throw new Error('Invalid payment info provided for Toss deep link')
-    }
-
-    return createTossDeepLink(info)
-  }
-
-  if (!isKakaoInfo(info)) {
-    throw new Error('Invalid payment info provided for Kakao deep link')
-  }
-
-  return createKakaoDeepLink(info)
-}
 
 let deepLinkLaunched = false
 window.addEventListener('blur', () => { deepLinkLaunched = true })

--- a/frontend/src/payments/services/paymentInfoService.ts
+++ b/frontend/src/payments/services/paymentInfoService.ts
@@ -1,5 +1,3 @@
-import type { DeepLinkProvider } from '@/payments/types'
-
 export type TransferAccount = {
   bank: string
   number: string
@@ -18,11 +16,13 @@ export type TransferPaymentInfo = {
 export type TossPaymentInfo = {
   amount: AmountKRW
   account: TransferAccount
+  deepLink: string
 }
 
 export type KakaoPaymentInfo = {
   amount: AmountKRW
   personalCode: string
+  deepLink: string
 }
 
 export type MethodUrlInfo = {
@@ -32,7 +32,6 @@ export type MethodUrlInfo = {
 export type AvailablePaymentMethod = {
   id: string
   supportedCurrencies: string[]
-  deepLinkProvider?: DeepLinkProvider
 }
 
 export type PaymentMethodDetail =

--- a/frontend/src/payments/stores/payment.store.ts
+++ b/frontend/src/payments/stores/payment.store.ts
@@ -25,7 +25,6 @@ export const usePaymentStore = defineStore('payment', () => {
     return {
       id: entry.id,
       icons,
-      deepLinkProvider: entry.deepLinkProvider,
       supportedCurrencies: entry.supportedCurrencies,
     }
   }

--- a/frontend/src/payments/stores/paymentInfo.store.ts
+++ b/frontend/src/payments/stores/paymentInfo.store.ts
@@ -1,7 +1,6 @@
 import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
 
-import type { DeepLinkProvider } from '@/payments/types'
 import {
   fetchPaymentMethodDetail,
   type KakaoPaymentInfo,
@@ -109,13 +108,15 @@ export const usePaymentInfoStore = defineStore('payment-info', () => {
     return firstUrl ?? null
   }
 
-  const getDeepLinkInfo = (provider: DeepLinkProvider): TossPaymentInfo | KakaoPaymentInfo | null => {
-    if (provider === 'toss') {
-      return tossInfo.value
+  const getMethodDeepLink = (methodId: 'toss' | 'kakao'): string | null => {
+    const detail = getDetail(methodId)
+
+    if (!detail) {
+      return null
     }
 
-    if (provider === 'kakao') {
-      return kakaoInfo.value
+    if (detail.type === 'toss' || detail.type === 'kakao') {
+      return detail.data.deepLink
     }
 
     return null
@@ -132,7 +133,7 @@ export const usePaymentInfoStore = defineStore('payment-info', () => {
     kakaoInfo,
     ensureMethodInfo,
     fetchMethodInfo,
-    getDeepLinkInfo,
+    getMethodDeepLink,
     getMethodInfo,
     getMethodUrl,
     isMethodLoading,

--- a/frontend/src/payments/types.ts
+++ b/frontend/src/payments/types.ts
@@ -1,5 +1,3 @@
-export type DeepLinkProvider = 'toss' | 'kakao'
-
 export type PaymentIcon = {
   src: string
   alt: string
@@ -8,7 +6,6 @@ export type PaymentIcon = {
 export type PaymentMethod = {
   id: string
   icons?: PaymentIcon[]
-  deepLinkProvider?: DeepLinkProvider
 }
 
 export type PaymentMethodWithCurrencies = PaymentMethod & {


### PR DESCRIPTION
## Summary
- add deep link URLs to the Toss and Kakao backend payloads and remove the deepLinkProvider flag from the method list
- update payment data types and stores so deep links are read directly from backend responses while simplifying the deep link service
- adjust Toss/Kakao flows and dialogs to rely on the backend-provided deep links

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0dd7b6c98832c823ebd152c52937f